### PR TITLE
Resolves #40 - added optional site class dataset to earthquake and li…

### DIFF
--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/Site.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/Site.java
@@ -15,8 +15,17 @@ public class Site {
     private Point location;
     private double depth = 0.0;
     private double vs30 = 760.0;
+    private String siteClass;
 
     public Site() {
+    }
+
+    public void setSiteClass(String siteClass) {
+        this.siteClass = siteClass;
+    }
+
+    public String getSiteClass() {
+        return this.siteClass;
     }
 
     public Site(Point location) {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
@@ -79,7 +79,6 @@ public class HazardCalc {
                 susceptibilitity = feature.getAttribute(HazardUtil.LIQ_SUSCEPTIBILITY).toString();
                 pgaValue = getGroundMotionAtSite(earthquake, attenuations, site, "0.0", HazardUtil.PGA,
                     HazardUtil.units_g, 0, true, siteClassFC, creator).getHazardValue();
-                System.out.println("PGA = " + pgaValue);
                 groundDeformation = liquefaction.getPermanentGroundDeformation(susceptibilitity, pgaValue, magnitude);
                 double liqProbability = liquefaction.getProbabilityOfLiquefaction(eqModel.getEqParameters().getMagnitude(), pgaValue,
                     susceptibilitity, groundWaterDepth);
@@ -121,7 +120,7 @@ public class HazardCalc {
 
         if (amplifyHazard && siteClassFC != null) {
             SimpleFeature feature = GISUtil.getPointInPolygon(site.getLocation(), siteClassFC);
-            if (feature != null) {
+            if (feature != null && feature.getAttribute(HazardUtil.SOILTYPE) != null) {
                 String siteClass = feature.getAttribute(HazardUtil.SOILTYPE).toString();
                 site.setSiteClass(siteClass);
             }

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
@@ -307,7 +307,7 @@ public class HazardCalc {
                 HazardUtil.getSiteClassAsInt(eqModel.getDefaultSiteClass());
 
             SiteAmplification siteAmplification = null;
-            if (amplifyHazard) {
+            if (amplifyHazard && siteClass != -1) {
                 // TODO need to add check for if VS already accounted for soil type
 
                 // TODO add check for Rix Fernandez, no need to amplify

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardUtil.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardUtil.java
@@ -41,6 +41,9 @@ public class HazardUtil {
     private static final Logger logger = Logger.getLogger(HazardUtil.class);
     public static final String HAZARD = "hazard";
 
+    public static final String LIQ_SUSCEPTIBILITY = "liq_suscep";
+    public static final String SOILTYPE = "soiltype";
+
     public static final String units_g = "g";
     public static final String units_cm = "cm";
     // Constant string expressions appearing throughout hazard code
@@ -58,7 +61,7 @@ public class HazardUtil {
     private static final String units_m_abbr = "m";
     private static final String units_cms = "cm/s";
     private static final String units_ins = "in/s";
-    // English
+    // Imperial
     public static final String units_in = "in";
     private static final String units_ft = "feet";
     private static final String units_ft_abbr = "ft";

--- a/server/hazard-service/src/test/java/edu/illinois/ncsa/incore/service/hazard/models/eq/attenuations/AtkinsonBoore1995Test.java
+++ b/server/hazard-service/src/test/java/edu/illinois/ncsa/incore/service/hazard/models/eq/attenuations/AtkinsonBoore1995Test.java
@@ -62,7 +62,7 @@ public class AtkinsonBoore1995Test {
         // TODO this should come from a mock eq
         Earthquake eq = new EarthquakeModel();
         SeismicHazardResult result = HazardCalc.getGroundMotionAtSite(eq, attenuations, site, period, demand, HazardUtil.units_g,
-            0, true, "incrtest");
+            0, true, null, "incrtest");
 
         double expected = 0.5322;
         assertEquals(expected, result.getHazardValue(), expected * 0.05);


### PR DESCRIPTION
Added new form parameter to specify site classification dataset for earthquake values and liquefaction values endpoint. To simplify the changes, I added a siteClass field to the Site object that provides site specific parameters. To test this, you will need two datasets from the service:

1. Memphis liquefaction susceptibility - 5a284f53c7d30d13bc08249c
2. Shelby county soil types - 5a284f56c7d30d13bc0824f6

I created an earthquake with atkinson and boore 1995 and the parameters in the README

For testing /api/earthquakes/{id}/values, use the following:
[{"demands": ["0.20 SA"], "units": ["g"], "loc": "35.05, -90.15"     } ]

For testing /api/earthquakes/{id}/liquefaction/values, use:
[ {"demands": ["PGD"], "units": ["in"], "loc": "35.05, -90.15"     } ]

I chose the site because it's actually in site class F so you should notice a difference in output when including/excluding site class since the default is site class D. 