### PR TITLE
14 add validation on delete dataset endpoint to check if there are associated hazards

### DIFF
--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
@@ -399,6 +399,9 @@ public class DatasetController {
 
         if (dataset == null) {
             throw new IncoreHTTPException(Response.Status.NOT_FOUND, "Could not find the dataset " + datasetId);
+        } else if (HazardConstants.DATA_TYPE_HAZARD.contains(dataset.getDataType())) {
+            throw new IncoreHTTPException(Response.Status.CONFLICT,
+                "This dataset is associated with a hazard and deleting it could lead to loss of data and errors in computation.");
         }
 
         String format = dataset.getFormat();
@@ -406,11 +409,6 @@ public class DatasetController {
         // if there is a source dataset, it will be have a geopkg file uploaded to geoserver
         if (sourceDataset.length() > 0 && format.equalsIgnoreCase("table")) {
             geoserverUsed = true;
-        }
-
-        if (HazardConstants.DATA_TYPE_HAZARD.contains(dataset.getDataType())) {
-            throw new IncoreHTTPException(Response.Status.CONFLICT,
-                "This dataset is associated with a hazard and deleting it could lead to loss of data and errors in computation.");
         }
 
         if (authorizer.canUserDeleteMember(this.username, datasetId, spaceRepository.getAllSpaces())) {

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
@@ -19,6 +19,7 @@ import edu.illinois.ncsa.incore.common.exceptions.IncoreHTTPException;
 import edu.illinois.ncsa.incore.common.models.Space;
 import edu.illinois.ncsa.incore.common.utils.JsonUtils;
 import edu.illinois.ncsa.incore.common.utils.UserInfoUtils;
+import edu.illinois.ncsa.incore.common.HazardConstants;
 import edu.illinois.ncsa.incore.service.data.dao.IRepository;
 import edu.illinois.ncsa.incore.service.data.models.Dataset;
 import edu.illinois.ncsa.incore.service.data.models.FileDescriptor;
@@ -405,6 +406,11 @@ public class DatasetController {
         // if there is a source dataset, it will be have a geopkg file uploaded to geoserver
         if (sourceDataset.length() > 0 && format.equalsIgnoreCase("table")) {
             geoserverUsed = true;
+        }
+
+        if (HazardConstants.DATA_TYPE_HAZARD.contains(dataset.getDataType())) {
+            throw new IncoreHTTPException(Response.Status.CONFLICT,
+                "This dataset is associated with a hazard and deleting it could lead to loss of data and errors in computation.");
         }
 
         if (authorizer.canUserDeleteMember(this.username, datasetId, spaceRepository.getAllSpaces())) {


### PR DESCRIPTION
To test, try locally deleting any dataset with the following data types (or the dataset 5f4807aa8538c817199e51ef):
* ergo:probabilisticEarthquakeRaster
* ergo:deterministicEarthquakeRaster
* incore:probabilisticTsunamiRaster
* incore:deterministicTsunamiRaster
* incore:probabilisticHurricaneRaster
* incore:deterministicHurricaneRaster
* incore:hurricaneGridSnapshot
* incore:tornadoWindfield
* incore:deterministicFloodRaster
* incore:probabilisticFloodRaster