### PR TITLE
32: Eq threshold management - removed period and used common method

### DIFF
--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/HazardDataset.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/HazardDataset.java
@@ -64,8 +64,8 @@ public abstract class HazardDataset {
 
     @JsonIgnore
     public String getThresholdJsonString(){
-        return String.format("{'%s': {'%s': {'value': %s, 'unit': '%s'}}  }",
-            this.demandType, this.period, this.threshold, this.demandUnits);
+        return String.format("{'%s': {'value': %s, 'unit': '%s'} }",
+            this.demandType, this.threshold, this.demandUnits);
     }
 
 }

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
@@ -204,65 +204,15 @@ public class HazardCalc {
         }
     }
 
-    // This method will be removed when we finalize the threshold management for Model based Eq. If defining a threshold for
-    // just PGA and 1.0 SA (or any SA without period) enough?
-    public static Double applyModelEqThresholds(double hazardValue, String demand, String demandUnits, String closestHazardPeriod) {
-        Double adjustedHazardValue = hazardValue;
-        JSONObject earthquakeThresholds = HazardUtil.toLowerKey(HazardUtil.EARTHQUAKE_THRESHOLDS); // convert demand type keys to lower case
-        if (earthquakeThresholds.has(demand.toLowerCase())) {
-            JSONObject demandThresholds = ((JSONObject) earthquakeThresholds.get(demand.toLowerCase()));
-            JSONObject periodThreshold = null;
-            String usedPeriod;
-            if (demandThresholds.has(closestHazardPeriod)) {
-                if (demandThresholds.get(closestHazardPeriod) != JSONObject.NULL) {
-                    periodThreshold = (JSONObject) demandThresholds.get(closestHazardPeriod);
-                }
-                usedPeriod = closestHazardPeriod;
-            } else {
-                // if there is no defined threshold for the period, use "0.0" as the default
-                if (demandThresholds.get("0.0") != JSONObject.NULL) {
-                    periodThreshold = ((JSONObject) demandThresholds.get("0.0"));
-                }
-                usedPeriod = "0.0";
-            }
-
-            // ignore threshold if null
-            if (periodThreshold != null) {
-                double threshold = HazardUtil.convertHazard(periodThreshold.getDouble("value"),
-                    periodThreshold.getString("unit"), Double.parseDouble(usedPeriod), demand.toLowerCase(),
-                    demandUnits, demand.toLowerCase());
-                if (hazardValue <= threshold) {
-                    adjustedHazardValue = null;
-                }
-            }
-        }
-        return adjustedHazardValue;
-    }
-
     public static Double applyEqThresholds(JSONObject earthquakeThresholds, double hazardValue,
                                            String demand, String demandUnits, String closestHazardPeriod) {
         Double adjustedHazardValue = hazardValue;
-        if (earthquakeThresholds.has(demand.toLowerCase())) {
+        if (earthquakeThresholds.has(demand.toLowerCase()) && earthquakeThresholds.get(demand.toLowerCase()) != JSONObject.NULL) {
             JSONObject demandThresholds = ((JSONObject) earthquakeThresholds.get(demand.toLowerCase()));
-            JSONObject periodThreshold = null;
-            String usedPeriod;
-            if (demandThresholds.has(closestHazardPeriod)) {
-                if (demandThresholds.get(closestHazardPeriod) != JSONObject.NULL) {
-                    periodThreshold = (JSONObject) demandThresholds.get(closestHazardPeriod);
-                }
-                usedPeriod = closestHazardPeriod;
-            } else {
-                // if there is no defined threshold for the period, use "0.0" as the default
-                if (demandThresholds.get("0.0") != JSONObject.NULL) {
-                    periodThreshold = ((JSONObject) demandThresholds.get("0.0"));
-                }
-                usedPeriod = "0.0";
-            }
 
-            // ignore threshold if null
-            if (periodThreshold != null) {
-                double threshold = HazardUtil.convertHazard(periodThreshold.getDouble("value"),
-                    periodThreshold.getString("unit"), Double.parseDouble(usedPeriod), demand.toLowerCase(),
+            if (demandThresholds.get("value") != JSONObject.NULL) {
+                double threshold = HazardUtil.convertHazard(demandThresholds.getDouble("value"),
+                    demandThresholds.getString("unit"), Double.parseDouble(closestHazardPeriod), demand.toLowerCase(),
                     demandUnits, demand.toLowerCase());
                 if (hazardValue <= threshold) {
                     adjustedHazardValue = null;
@@ -334,8 +284,8 @@ public class HazardCalc {
             if (Double.parseDouble(period) == 0.0) {
                 closestHazardPeriod = "0.0";
             }
-
-            Double adjHazardVal = HazardCalc.applyModelEqThresholds(hazardValue, demand, demandUnits, closestHazardPeriod);
+            JSONObject eqThresholds = HazardUtil.toLowerKey(HazardUtil.EARTHQUAKE_THRESHOLDS);
+            Double adjHazardVal = HazardCalc.applyEqThresholds(eqThresholds, hazardValue, demand, demandUnits, closestHazardPeriod);
             return new SeismicHazardResult(adjHazardVal, closestHazardPeriod, demand);
 
         } else {
@@ -345,15 +295,15 @@ public class HazardCalc {
 
             GridCoverage gc = GISUtil.getGridCoverage(hazardDataset.getDatasetId(), creator);
             try {
-                JSONObject EqThresholds;
+                JSONObject eqThresholds;
                 if (hazardDataset.getThreshold() != null) {
-                    EqThresholds = HazardUtil.toLowerKey(new JSONObject(hazardDataset.getThresholdJsonString()));
+                    eqThresholds = HazardUtil.toLowerKey(new JSONObject(hazardDataset.getThresholdJsonString()));
                 } else {
-                    EqThresholds = HazardUtil.toLowerKey(HazardUtil.EARTHQUAKE_THRESHOLDS);
+                    eqThresholds = HazardUtil.toLowerKey(HazardUtil.EARTHQUAKE_THRESHOLDS);
                 }
 
                 hazardValue = HazardUtil.findRasterPoint(site.getLocation(), (GridCoverage2D) gc);
-                Double adjHazardVal = HazardCalc.applyEqThresholds(EqThresholds,
+                Double adjHazardVal = HazardCalc.applyEqThresholds(eqThresholds,
                     hazardValue, hazardDataset.getDemandType(), hazardDataset.getDemandUnits(), closestHazardPeriod);
 
                 if (adjHazardVal != null) {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
@@ -243,6 +243,7 @@ public class HazardCalc {
             while (iterator.hasNext()) {
                 BaseAttenuation model = iterator.next();
                 double weight = attenuations.get(model);
+                demandUnits = BaseAttenuation.getUnits(demand);
                 SeismicHazardResult matchedResult = model.getValueClosestMatch(hazardType, site);
 
                 hazardValue += (Math.log(matchedResult.getHazardValue()) * weight);

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardUtil.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardUtil.java
@@ -109,12 +109,12 @@ public class HazardUtil {
     // TODO: This json with period is getting hard to read. Move to a static json file - should we use the demand type and unit
     //  definition constants defined here?.
     public final static JSONObject EARTHQUAKE_THRESHOLDS = new JSONObject("{ " +
-        "'" + PGA + "': {'value': 0.01, 'unit': 'g'}," +
-        "'" + PGV + "': {'value': 0.01, 'unit': 'in/sec'}," +
+        "'" + PGA + "': {'value': 3.01, 'unit': 'g'}," +
+        "'" + PGV + "': {'value': 0.01, 'unit': 'in/s'}," +
         "'" + PGD + "': {'value': 0.01, 'unit': 'in'}," +
         "'" + SA + "': {'value': 0.01, 'unit': 'g'}," +
         "'" + SD + "': {'value': 0.01, 'unit': 'in'}," +
-        "'" + SV + "': {'value': 0.01, 'unit': 'in/sec'}" +
+        "'" + SV + "': {'value': 0.01, 'unit': 'in/s'}" +
         "}");
 
     // Provide null to ignore threshold value. Demand Type key is case insensitive

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardUtil.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardUtil.java
@@ -73,6 +73,7 @@ public class HazardUtil {
     private static final String sa_sd = "sasd";
     private static final String sd_sd = "sdsd";
     private static final String pgv_pgv = "pgvpgv";
+    private static final String sv_sv = "svsv";
     private static final String FAULT_LENGTH = "Length";
     private static final String FAULT_WIDTH = "Width";
     public static double R_EARTH = 6373.0; // km
@@ -109,7 +110,7 @@ public class HazardUtil {
     // TODO: This json with period is getting hard to read. Move to a static json file - should we use the demand type and unit
     //  definition constants defined here?.
     public final static JSONObject EARTHQUAKE_THRESHOLDS = new JSONObject("{ " +
-        "'" + PGA + "': {'value': 3.01, 'unit': 'g'}," +
+        "'" + PGA + "': {'value': 0.01, 'unit': 'g'}," +
         "'" + PGV + "': {'value': 0.01, 'unit': 'in/s'}," +
         "'" + PGD + "': {'value': 0.01, 'unit': 'in'}," +
         "'" + SA + "': {'value': 0.01, 'unit': 'g'}," +
@@ -221,7 +222,7 @@ public class HazardUtil {
         } else if (concat.equalsIgnoreCase(sa_sd)) {
             return convertSAToSD(hazard, t, units0, units1);
         } else if (concat.equalsIgnoreCase(sa_sv)) {
-            return convertSAToSV(hazard, t, units0);
+            return convertSAToSV(hazard, t, units0, units1);
         } else if (concat.equalsIgnoreCase(sd_sd)) {
             return getCorrectUnitsOfSD(hazard, units0, units1);
         } else if (concat.equalsIgnoreCase(pga_pgd)) {
@@ -230,6 +231,9 @@ public class HazardUtil {
         } else if (concat.equalsIgnoreCase(pgv_pgv)) {
             // logger.debug( "***************hazard val in: " + hazard );
             return getCorrectUnitsOfPGV(hazard, units0, units1);
+        } else if (concat.equalsIgnoreCase(sv_sv)) {
+            // logger.debug( "***************hazard val in: " + hazard );
+            return getCorrectUnitsOfSV(hazard, units0, units1);
         }
         return hazard;
     }
@@ -298,9 +302,9 @@ public class HazardUtil {
      * @param units0 units of Sa
      * @return spectral velocity in cm/s
      */
-    private static double convertSAToSV(double sa, double t, String units0) {
+    private static double convertSAToSV(double sa, double t, String units0, String units1) {
         sa = getCorrectUnitsOfSA(sa, units0, units_g);
-        return sa * 9.8 * t / (2 * Math.PI);
+        return getCorrectUnitsOfSV(sa * 9.8 * t / (2 * Math.PI), units_cms, units1);
     }
 
     /**
@@ -398,9 +402,30 @@ public class HazardUtil {
             return pgv;
         } else if (units_ins.equalsIgnoreCase(units1) && units_cms.equalsIgnoreCase(units0)) {
             return pgv / 2.54;
+        } else if (units_cms.equalsIgnoreCase(units1) && units_ins.equalsIgnoreCase(units0)) {
+            return pgv * 2.54;
         } else {
             logger.warn("Unknown pgv unit, returning unconverted pgv value");
             return pgv;
+        }
+    }
+
+    /**
+     * @param sv
+     * @param units0
+     * @param units1
+     * @return
+     */
+    public static double getCorrectUnitsOfSV(double sv, String units0, String units1) {
+        if (units1 != null && units1.equalsIgnoreCase(units0)) {
+            return sv;
+        } else if (units_ins.equalsIgnoreCase(units1) && units_cms.equalsIgnoreCase(units0)) {
+            return sv / 2.54;
+        } else if (units_cms.equalsIgnoreCase(units1) && units_ins.equalsIgnoreCase(units0)) {
+            return sv * 2.54;
+        } else {
+            logger.warn("Unknown sv unit, returning unconverted s value");
+            return sv;
         }
     }
 

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardUtil.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardUtil.java
@@ -109,20 +109,12 @@ public class HazardUtil {
     // TODO: This json with period is getting hard to read. Move to a static json file - should we use the demand type and unit
     //  definition constants defined here?.
     public final static JSONObject EARTHQUAKE_THRESHOLDS = new JSONObject("{ " +
-        "'" + PGA + "': {'0.0' : null}," +
-        "'" + PGV + "': {'0.0' : null}," +
-        "'" + PGD + "': {'0.0' : null}," +
-        "'" + SA + "':{'0.2': null," +
-        "'0.3': null," +
-        "'1.0': null," +
-        "'0.0': null," +
-        "}," +
-        "'" + SD + "':{'0.2': null," +
-        "'0.3': null," +
-        "'1.0': null," +
-        "'0.0': null," +
-        "}," +
-        "'" + SV + "': {'0.0' : null}," +
+        "'" + PGA + "': {'value': 0.01, 'unit': 'g'}," +
+        "'" + PGV + "': {'value': 0.01, 'unit': 'in/sec'}," +
+        "'" + PGD + "': {'value': 0.01, 'unit': 'in'}," +
+        "'" + SA + "': {'value': 0.01, 'unit': 'g'}," +
+        "'" + SD + "': {'value': 0.01, 'unit': 'in'}," +
+        "'" + SV + "': {'value': 0.01, 'unit': 'in/sec'}" +
         "}");
 
     // Provide null to ignore threshold value. Demand Type key is case insensitive


### PR DESCRIPTION
Used common method for both model and dataset based. Removed period in threshold definition
To test:
- create a model based earthquake. Adjust `EARTHQUAKE_THRESHOLDS` in `HazardUtil.java`, and verify that the POST /values endpoint returns null when threshold is not met.
- create a dataset based earthquake. Set threshold value in the EQ metadata for each associated dataset. Verify that the POST /values endpoint returns null when threshold is not met. When threshold from metadata is null, it will use the thresholds defined in `EARTHQUAKE_THRESHOLDS`

Threshold checks can be disabled if the JSON "value" of the demand (key) is null in the `EARTHQUAKE_THRESHOLDS`.

Refer to past PR for more background on threshold functionality: #21 

Next step for this task: Store these thresholds in the `Commondb.Demand` table and fetch from there, instead of hard-coding