### PR TITLE
76 create an endpoint for showing logged in users allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+# Added
+- Endpoint for giving logged in user's allocation [#76](https://github.com/IN-CORE/incore-services/issues/76)
+
 ## [1.9.0] - 2022-03-29
 # Added
 - User Allocation management to limit usage per user or group. Added validations to deny creation of new datasets, hazards and DFR3 curves when the allocations limits are met. [#66](https://github.com/IN-CORE/incore-services/issues/66) 

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/AllocationConstants.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/AllocationConstants.java
@@ -10,12 +10,12 @@
 package edu.illinois.ncsa.incore.common;
 
 public class AllocationConstants {
-    public static final int NUM_DATASETS = 1000;
-    public static final int NUM_HAZARDS = 1000;
-    public static final int NUM_HAZARD_DATASETS = 1000;
-    public static final int NUM_DFR3 = 1000;
-    public static final long DATASET_SIZE = 21474836480L;
-    public static final long HAZARD_DATASET_SIZE = 21474836480L;
+    public static final int NUM_DATASETS = 100;
+    public static final int NUM_HAZARDS = 100;
+    public static final int NUM_HAZARD_DATASETS = 100;
+    public static final int NUM_DFR3 = 100;
+    public static final long DATASET_SIZE = 2147483648L;
+    public static final long HAZARD_DATASET_SIZE = 2147483648L;
     public static final String DATASET_ALLOCATION_MESSAGE =
         "You have reached the maximum number of datasets you can create for your allocation. " +
             "Your request will be aborted. You either need to increase your allocation " +

--- a/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/controllers/AllocationsController.java
+++ b/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/controllers/AllocationsController.java
@@ -66,12 +66,21 @@ public class AllocationsController {
     private static final Logger logger = Logger.getLogger(AllocationsController.class);
 
     @GET
-    @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Gives the status of the service.",
-        notes = "This will provide the status of the service as a JSON.")
-    public String getStatus() {
-        String statusJson = "{\"status\": \"responding\"}";
-        return statusJson;
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Gives the allocation and can be used as status check as well.",
+        notes = "This will provide the allocation of the logged in user.")
+    public String getUsage(@HeaderParam("x-auth-userinfo") String userInfo) {
+        JSONObject outJson = null;
+
+        String username = JsonUtils.parseUserName(userInfo);
+
+        try {
+            outJson = JsonUtils.createUserFinalQuotaJson(username, finalQuotaRepository);
+        } catch (ParseException e) {
+            logger.error("Error extracting allocation");
+            throw new IncoreHTTPException(Response.Status.INTERNAL_SERVER_ERROR, "Error extracting allocation");
+        }
+        return outJson.toString();
     }
 
     @GET


### PR DESCRIPTION
This will show the allocation information of the logged in user. Test it by accessing `http://localhost:8080/space/api/allocations`