### PR TITLE
Network dataset's NetworkDataset property has been changed to use dataType instead of networkType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 # Added
 - Endpoint for giving logged in user's allocation [#76](https://github.com/IN-CORE/incore-services/issues/76)
 
+# Changed
+- Network dataset's sub data's dataType changed from networkType to dataType [#79](https://github.com/IN-CORE/incore-services/issues/79)
+
 ## [1.9.0] - 2022-03-29
 # Added
 - User Allocation management to limit usage per user or group. Added validations to deny creation of new datasets, hazards and DFR3 curves when the allocations limits are met. [#66](https://github.com/IN-CORE/incore-services/issues/66) 

--- a/server/data-service/README.md
+++ b/server/data-service/README.md
@@ -47,7 +47,7 @@ To start the service
    | | | input json example when it is a result dataset example (parameter name : dataset, item type: text) |
    | | | { dataType: "http://localhost:8080/semantics/edu.illinois.ncsa.ergo.eq.schemas.buildingDamageVer4.v1.0", title: "shelby building damage", sourceDataset: "59e5098168f47426547409f3", format: "csv"} |
    | | | input json example when it is a parent network dataset (parameter name: dataset, item type: text) |
-   | | | { dataType: "http://localhost:8080/semantics/edu.illinois.ncsa.ergo.eq.schemas.epnNetworkVer1.v1.0", title: "Shelby_County_Electric_Pipeline_Network", sourceDataset: "", format: "shp-network", networkDataset:{link:{dataType:  "incore:pipeline"}, node:{dataType: "incore:waterFacility"}, graph:{dataType: "incore:networkGraph"}} |
+   | | | { dataType: "http://localhost:8080/semantics/edu.illinois.ncsa.ergo.eq.schemas.epnNetworkVer1.v1.0", title: "Centerville epn network", sourceDataset: "", format: "shp-network", networkDataset:{link:{dataType:  "incore:epnLinkVer1"}, node:{dataType: "incore:epnNodeVer1"}, graph:{dataType: "incore:epnGraph"}} |
    | | | output: Dataset |
    | /{id}/files | POST | upload file(s) to attach to a dataset by FileDescriptor |
    | | | headers: Form |

--- a/server/data-service/README.md
+++ b/server/data-service/README.md
@@ -47,7 +47,7 @@ To start the service
    | | | input json example when it is a result dataset example (parameter name : dataset, item type: text) |
    | | | { dataType: "http://localhost:8080/semantics/edu.illinois.ncsa.ergo.eq.schemas.buildingDamageVer4.v1.0", title: "shelby building damage", sourceDataset: "59e5098168f47426547409f3", format: "csv"} |
    | | | input json example when it is a parent network dataset (parameter name: dataset, item type: text) |
-   | | | { dataType: "http://localhost:8080/semantics/edu.illinois.ncsa.ergo.eq.schemas.buildingInventoryVer4.v1.0", title: "Shelby_County_Essential_Facilities", sourceDataset: "", format: "shp-network", networkDataset:{link:{linkType:  "pipeline"}, node:{networkType: "water facility"}, graph:{graphType: "table"}} |
+   | | | { dataType: "http://localhost:8080/semantics/edu.illinois.ncsa.ergo.eq.schemas.buildingInventoryVer4.v1.0", title: "Shelby_County_Essential_Facilities", sourceDataset: "", format: "shp-network", networkDataset:{link:{dataType:  "pipeline"}, node:{dataType: "water facility"}, graph:{dataType: "table"}} |
    | | | output: Dataset |
    | /{id}/files | POST | upload file(s) to attach to a dataset by FileDescriptor |
    | | | headers: Form |

--- a/server/data-service/README.md
+++ b/server/data-service/README.md
@@ -47,7 +47,7 @@ To start the service
    | | | input json example when it is a result dataset example (parameter name : dataset, item type: text) |
    | | | { dataType: "http://localhost:8080/semantics/edu.illinois.ncsa.ergo.eq.schemas.buildingDamageVer4.v1.0", title: "shelby building damage", sourceDataset: "59e5098168f47426547409f3", format: "csv"} |
    | | | input json example when it is a parent network dataset (parameter name: dataset, item type: text) |
-   | | | { dataType: "http://localhost:8080/semantics/edu.illinois.ncsa.ergo.eq.schemas.buildingInventoryVer4.v1.0", title: "Shelby_County_Essential_Facilities", sourceDataset: "", format: "shp-network", networkDataset:{link:{dataType:  "pipeline"}, node:{dataType: "water facility"}, graph:{dataType: "table"}} |
+   | | | { dataType: "http://localhost:8080/semantics/edu.illinois.ncsa.ergo.eq.schemas.epnNetworkVer1.v1.0", title: "Shelby_County_Electric_Pipeline_Network", sourceDataset: "", format: "shp-network", networkDataset:{link:{dataType:  "incore:pipeline"}, node:{dataType: "incore:waterFacility"}, graph:{dataType: "incore:networkGraph"}} |
    | | | output: Dataset |
    | /{id}/files | POST | upload file(s) to attach to a dataset by FileDescriptor |
    | | | headers: Form |

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/models/NetworkData.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/models/NetworkData.java
@@ -4,16 +4,16 @@ import dev.morphia.annotations.Embedded;
 
 @Embedded
 public class NetworkData {
-    private String networkType;
+    private String dataType;
 
     private String fileName;
 
-    public String getNetworkType() {
-        return networkType;
+    public String getDataType() {
+        return dataType;
     }
 
-    public void setNetworkType(String networkType) {
-        this.networkType = networkType;
+    public void setDataType(String dataType) {
+        this.dataType = dataType;
     }
 
     public String getFileName() {

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/DataJsonUtils.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/DataJsonUtils.java
@@ -148,15 +148,15 @@ public class DataJsonUtils {
 
         componentStr = JsonUtils.extractValueFromJsonString(FileUtils.NETWORK_COMPONENT, inJson);
         linkStr = JsonUtils.extractValueFromJsonString(FileUtils.NETWORK_LINK, componentStr);
-        linkType = JsonUtils.extractValueFromJsonString(FileUtils.NETWORK_LINK_TYPE, linkStr);
+        linkType = JsonUtils.extractValueFromJsonString(FileUtils.DATASET_TYPE, linkStr);
         nodeStr = JsonUtils.extractValueFromJsonString(FileUtils.NETWORK_NODE, componentStr);
-        nodeType = JsonUtils.extractValueFromJsonString(FileUtils.NETWORK_NODE_TYPE, nodeStr);
+        nodeType = JsonUtils.extractValueFromJsonString(FileUtils.DATASET_TYPE, nodeStr);
         graphStr = JsonUtils.extractValueFromJsonString(FileUtils.NETWORK_GRAPH, componentStr);
-        graphType = JsonUtils.extractValueFromJsonString(FileUtils.NETWORK_GRAPH_TYPE, graphStr);
+        graphType = JsonUtils.extractValueFromJsonString(FileUtils.DATASET_TYPE, graphStr);
 
-        link.setNetworkType(linkType);
-        node.setNetworkType(nodeType);
-        graph.setNetworkType(graphType);
+        link.setDataType(linkType);
+        node.setDataType(nodeType);
+        graph.setDataType(graphType);
         networkDataset.setLink(link);
         networkDataset.setNode(node);
         networkDataset.setGraph(graph);

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/FileUtils.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/FileUtils.java
@@ -69,9 +69,6 @@ public class FileUtils {
     public static final String NETWORK_LINK = "link";
     public static final String NETWORK_NODE = "node";
     public static final String NETWORK_GRAPH = "graph";
-    public static final String NETWORK_LINK_TYPE = "linkType";
-    public static final String NETWORK_NODE_TYPE = "nodeType";
-    public static final String NETWORK_GRAPH_TYPE = "graphType";
     public static final Logger logger = Logger.getLogger(FileUtils.class);
     private static final String DATA_REPO_FOLDER = System.getenv("DATA_REPO_DATA_DIR");
 


### PR DESCRIPTION
Network dataset's NetworkDataset property has been changed to use dataType instead of networkType. 

You can create a dataset based on this 
https://wiki.ncsa.illinois.edu/display/INCORE/Network+Dataset

After posting the dataset, there is a property of `networkDataset` inside the posted dataset. The dataType for each node, link, and graph were `networkType` but they are changed to `dataType`