### PR TITLE
Fixes #108 earthquake hazard raster didn't handle null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.13.1] - 2023-03-15
+### Fixed
+- Earthquake hazard raster didn't handle values below the threshold that were set to null[#108](https://github.com/IN-CORE/incore-services/issues/108)
+
 ## [1.13.0] - 2023-03-08
 ### Added
 - Space endpoint for getting space by providing the name of the space [#101](https://github.com/IN-CORE/incore-services/issues/101)

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -50,7 +50,7 @@ apply plugin: 'war'
 // This will not apply to the war files we build unless we put it within project loop
 // at the end of this file. This is only for the docker build to pull a version
 war {
-    archiveVersion = '1.13.0'
+    archiveVersion = '1.13.1'
 }
 
 apply plugin: 'org.gretty'

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
@@ -429,9 +429,14 @@ public class HazardCalc {
             startX = (float) minX + (cellsize / 2.0f);
             for (int x = 0; x < width; x++) {
                 localSite = new Site(factory.createPoint(new Coordinate(startX, startY)));
-                double hazardValue = getGroundMotionAtSite(scenarioEarthquake, attenuations,
-                    localSite, demandComponents[0], demandComponents[1], demandUnits,
-                    0, amplifyHazard, null, creator).getHazardValue();
+                SeismicHazardResult hazardValueObj = getGroundMotionAtSite(scenarioEarthquake, attenuations, localSite, demandComponents[0],
+                    demandComponents[1], demandUnits, 0, amplifyHazard, null, creator);
+
+                // If the hazard is below the threshold it will be null so we'll set it to -9999
+                double hazardValue = -9999;
+                if (hazardValueObj.getHazardValue() != null) {
+                    hazardValue = hazardValueObj.getHazardValue();
+                }
 
                 raster.setSample(x, y, 0, hazardValue);
 


### PR DESCRIPTION
This is a hot fix for the main branch to fix the case where if a hazard value was below a minimum threshold, it was set to null to indicate not exposed when doing the damage analysis. If we see null, we'll instead set the value to -9999. 