### PR TITLE
111 add ascending decending parameter to get all endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] 
+### Added
+- Query parameters for sorting by given field in ascending and descending order [#111](https://github.com/IN-CORE/incore-services/issues/111)
+
 ## [1.13.1] - 2023-03-15
 ### Fixed
 - Earthquake hazard raster didn't handle values below the threshold that were set to null[#108](https://github.com/IN-CORE/incore-services/issues/108)

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/CommonUtil.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/CommonUtil.java
@@ -1,0 +1,21 @@
+package edu.illinois.ncsa.incore.service.data.utils;
+
+import edu.illinois.ncsa.incore.service.data.models.Dataset;
+
+import java.util.Comparator;
+
+public class CommonUtil {
+    public static Comparator<Dataset> datasetComparator(String sortBy, String order){
+        // construct comparator
+        Comparator<Dataset> comparator;
+        if (sortBy.equals("title")) {
+            comparator = Comparator.comparing(Dataset::getTitle);
+        }
+        else{
+            // default to date
+            comparator = Comparator.comparing(Dataset::getDate);
+        }
+        if (order.equals("desc")) comparator = comparator.reversed();
+        return comparator;
+    }
+}

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
@@ -296,7 +296,7 @@ public class EarthquakeController {
         @ApiParam(value = "Skip the first n results.") @QueryParam("skip") int offset,
         @ApiParam(value = "Limit number of results to return.") @DefaultValue("100") @QueryParam("limit") int limit
     ) {
-        // ipmort eq comparator
+        // import eq comparator
         Comparator<Earthquake> comparator = eqComparator(sortBy, order);
 
         try {
@@ -1014,7 +1014,7 @@ public class EarthquakeController {
         @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
         @ApiParam(value = "Limit number of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
 
-        // ipmort eq comparator
+        // import eq comparator
         Comparator<Earthquake> comparator = eqComparator(sortBy, order);
 
         List<Earthquake> earthquakes;

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
@@ -63,6 +63,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.*;
+import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.eqComparator;
 import static java.util.Comparator.comparing;
 
 
@@ -291,9 +292,13 @@ public class EarthquakeController {
     @ApiOperation(value = "Returns all earthquakes.")
     public List<Earthquake> getEarthquakes(
         @ApiParam(value = "Name of the space.") @DefaultValue("") @QueryParam("space") String spaceName,
+        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
         @ApiParam(value = "Skip the first n results.") @QueryParam("skip") int offset,
-        @ApiParam(value = "Limit number of results to return.") @DefaultValue("100") @QueryParam("limit") int limit,
+        @ApiParam(value = "Limit number of results to return.") @DefaultValue("100") @QueryParam("limit") int limit
     ) {
+        // ipmort eq comparator
+        Comparator<Earthquake> comparator = eqComparator(sortBy, order);
 
         try {
             List<Earthquake> earthquakes = repository.getEarthquakes();
@@ -311,7 +316,7 @@ public class EarthquakeController {
 
                 earthquakes = earthquakes.stream()
                     .filter(earthquake -> spaceMembers.contains(earthquake.getId()))
-                    .sorted(comparing(Earthquake::getDate).reversed())
+                    .sorted(comparator)
                     .skip(offset)
                     .limit(limit)
                     .map(d -> {
@@ -326,7 +331,7 @@ public class EarthquakeController {
             Set<String> membersSet = authorizer.getAllMembersUserHasReadAccessTo(this.username, spaceRepository.getAllSpaces());
             List<Earthquake> accessibleEarthquakes = earthquakes.stream()
                 .filter(earthquake -> membersSet.contains(earthquake.getId()))
-                .sorted(comparing(Earthquake::getDate).reversed())
+                .sorted(comparator)
                 .skip(offset)
                 .limit(limit)
                 .map(d -> {
@@ -1005,8 +1010,13 @@ public class EarthquakeController {
     })
     public List<Earthquake> findEarthquakes(
         @ApiParam(value = "Text to search by", example = "building") @QueryParam("text") String text,
+        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
         @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
         @ApiParam(value = "Limit number of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+
+        // ipmort eq comparator
+        Comparator<Earthquake> comparator = eqComparator(sortBy, order);
 
         List<Earthquake> earthquakes;
         Earthquake earthquake = repository.getEarthquakeById(text);
@@ -1021,7 +1031,7 @@ public class EarthquakeController {
         Set<String> membersSet = authorizer.getAllMembersUserHasReadAccessTo(this.username, spaceRepository.getAllSpaces());
         earthquakes = earthquakes.stream()
             .filter(b -> membersSet.contains(b.getId()))
-            .sorted(comparing(Earthquake::getDate).reversed())
+            .sorted(comparator)
             .skip(offset)
             .limit(limit)
             .map(d -> {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
@@ -64,7 +64,6 @@ import java.util.stream.Collectors;
 
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.*;
 import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.eqComparator;
-import static java.util.Comparator.comparing;
 
 
 // @SwaggerDefinition is common for all the service's controllers and can be put in any one of them

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
@@ -63,6 +63,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.*;
+import static java.util.Comparator.comparing;
 
 
 // @SwaggerDefinition is common for all the service's controllers and can be put in any one of them
@@ -291,7 +292,8 @@ public class EarthquakeController {
     public List<Earthquake> getEarthquakes(
         @ApiParam(value = "Name of the space.") @DefaultValue("") @QueryParam("space") String spaceName,
         @ApiParam(value = "Skip the first n results.") @QueryParam("skip") int offset,
-        @ApiParam(value = "Limit number of results to return.") @DefaultValue("100") @QueryParam("limit") int limit) {
+        @ApiParam(value = "Limit number of results to return.") @DefaultValue("100") @QueryParam("limit") int limit,
+    ) {
 
         try {
             List<Earthquake> earthquakes = repository.getEarthquakes();
@@ -309,6 +311,7 @@ public class EarthquakeController {
 
                 earthquakes = earthquakes.stream()
                     .filter(earthquake -> spaceMembers.contains(earthquake.getId()))
+                    .sorted(comparing(Earthquake::getDate).reversed())
                     .skip(offset)
                     .limit(limit)
                     .map(d -> {
@@ -323,6 +326,7 @@ public class EarthquakeController {
             Set<String> membersSet = authorizer.getAllMembersUserHasReadAccessTo(this.username, spaceRepository.getAllSpaces());
             List<Earthquake> accessibleEarthquakes = earthquakes.stream()
                 .filter(earthquake -> membersSet.contains(earthquake.getId()))
+                .sorted(comparing(Earthquake::getDate).reversed())
                 .skip(offset)
                 .limit(limit)
                 .map(d -> {
@@ -1017,6 +1021,7 @@ public class EarthquakeController {
         Set<String> membersSet = authorizer.getAllMembersUserHasReadAccessTo(this.username, spaceRepository.getAllSpaces());
         earthquakes = earthquakes.stream()
             .filter(b -> membersSet.contains(b.getId()))
+            .sorted(comparing(Earthquake::getDate).reversed())
             .skip(offset)
             .limit(limit)
             .map(d -> {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/FloodController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/FloodController.java
@@ -104,7 +104,7 @@ public class FloodController {
         @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
         @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
 
-        // ipmort flood comparator
+        // import flood comparator
         Comparator<Flood> comparator = floodComparator(sortBy, order);
 
         List<Flood> floods = repository.getFloods();
@@ -420,7 +420,7 @@ public class FloodController {
         @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
         @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
 
-        // ipmort flood comparator
+        // import flood comparator
         Comparator<Flood> comparator = floodComparator(sortBy, order);
 
         List<Flood> floods;

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/FloodController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/FloodController.java
@@ -52,11 +52,13 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.*;
+import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.floodComparator;
 
 @Api(value = "floods", authorizations = {})
 
@@ -97,8 +99,13 @@ public class FloodController {
     @ApiOperation(value = "Returns all floods.")
     public List<Flood> getFloods(
         @ApiParam(value = "Name of space.") @DefaultValue("") @QueryParam("space") String spaceName,
+        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
         @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
         @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+
+        // ipmort flood comparator
+        Comparator<Flood> comparator = floodComparator(sortBy, order);
 
         List<Flood> floods = repository.getFloods();
         if (!spaceName.equals("")) {
@@ -113,6 +120,7 @@ public class FloodController {
             List<String> spaceMembers = space.getMembers();
             floods = floods.stream()
                 .filter(flood -> spaceMembers.contains(flood.getId()))
+                .sorted(comparator)
                 .skip(offset)
                 .limit(limit)
                 .map(d -> {
@@ -126,6 +134,7 @@ public class FloodController {
         Set<String> membersSet = authorizer.getAllMembersUserHasReadAccessTo(this.username, spaceRepository.getAllSpaces());
         List<Flood> accessibleFloods = floods.stream()
             .filter(flood -> membersSet.contains(flood.getId()))
+            .sorted(comparator)
             .skip(offset)
             .limit(limit)
             .map(d -> {
@@ -406,8 +415,13 @@ public class FloodController {
     })
     public List<Flood> findFloods(
         @ApiParam(value = "Text to search by", example = "building") @QueryParam("text") String text,
+        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
         @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
         @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+
+        // ipmort flood comparator
+        Comparator<Flood> comparator = floodComparator(sortBy, order);
 
         List<Flood> floods;
         Flood flood = repository.getFloodById(text);
@@ -423,6 +437,7 @@ public class FloodController {
 
         floods = floods.stream()
             .filter(b -> membersSet.contains(b.getId()))
+            .sorted(comparator)
             .skip(offset)
             .limit(limit)
             .map(d -> {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TsunamiController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TsunamiController.java
@@ -54,11 +54,14 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.*;
+import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.tornadoComparator;
+import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.tsunamiComparator;
 
 @Api(value = "tsunamis", authorizations = {})
 
@@ -99,8 +102,13 @@ public class TsunamiController {
     @ApiOperation(value = "Returns all tsunamis.")
     public List<Tsunami> getTsunamis(
         @ApiParam(value = "Space name") @DefaultValue("") @QueryParam("space") String spaceName,
+        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
         @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
         @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+
+        // import tsunami comparator
+        Comparator<Tsunami> comparator = tsunamiComparator(sortBy, order);
 
         if (!spaceName.equals("")) {
             Space space = spaceRepository.getSpaceByName(spaceName);
@@ -115,6 +123,7 @@ public class TsunamiController {
             List<Tsunami> tsunamis = repository.getTsunamis();
             tsunamis = tsunamis.stream()
                 .filter(tsunami -> spaceMembers.contains(tsunami.getId()))
+                .sorted(comparator)
                 .skip(offset)
                 .limit(limit)
                 .map(d -> {
@@ -130,6 +139,7 @@ public class TsunamiController {
 
         List<Tsunami> accessibleTsunamis = tsunamis.stream()
             .filter(tsunami -> membersSet.contains(tsunami.getId()))
+            .sorted(comparator)
             .skip(offset)
             .limit(limit)
             .map(d -> {
@@ -408,8 +418,13 @@ public class TsunamiController {
     })
     public List<Tsunami> findTsunamis(
         @ApiParam(value = "Text to search by", example = "building") @QueryParam("text") String text,
+        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
         @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
         @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+
+        // import tsunami comparator
+        Comparator<Tsunami> comparator = tsunamiComparator(sortBy, order);
 
         List<Tsunami> tsunamis;
         Tsunami tsunami = repository.getTsunamiById(text);
@@ -425,6 +440,7 @@ public class TsunamiController {
 
         tsunamis = tsunamis.stream()
             .filter(b -> membersSet.contains(b.getId()))
+            .sorted(comparator)
             .skip(offset)
             .limit(limit)
             .map(d -> {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/utils/CommonUtil.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/utils/CommonUtil.java
@@ -2,10 +2,12 @@ package edu.illinois.ncsa.incore.service.hazard.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.illinois.ncsa.incore.common.exceptions.IncoreHTTPException;
+import edu.illinois.ncsa.incore.service.hazard.models.eq.Earthquake;
 import edu.illinois.ncsa.incore.service.hazard.models.eq.types.IncorePoint;
 import org.json.simple.JSONObject;
 
 import javax.ws.rs.core.Response;
+import java.util.Comparator;
 import java.util.List;
 
 public class CommonUtil {
@@ -43,5 +45,22 @@ public class CommonUtil {
         outJson.put("total_number_of_hazard", numHazard);
 
         return outJson;
+    }
+
+    public static Comparator<Earthquake> eqComparator(String sortBy, String order){
+        // construct comparator
+        Comparator<Earthquake> comparator = (f1, f2) -> {
+            if (sortBy.equals("name")) {
+                return f1.getName().compareTo(f2.getName());
+            } else if (sortBy.equals("creator")){
+                return f1.getCreator().compareTo(f2.getCreator());
+                // default to date
+            } else{
+                return f1.getDate().compareTo(f2.getDate());
+            }
+        };
+        if (order.equals("desc")) comparator = comparator.reversed();
+
+        return comparator;
     }
 }

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/utils/CommonUtil.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/utils/CommonUtil.java
@@ -4,6 +4,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.illinois.ncsa.incore.common.exceptions.IncoreHTTPException;
 import edu.illinois.ncsa.incore.service.hazard.models.eq.Earthquake;
 import edu.illinois.ncsa.incore.service.hazard.models.eq.types.IncorePoint;
+import edu.illinois.ncsa.incore.service.hazard.models.flood.Flood;
+import edu.illinois.ncsa.incore.service.hazard.models.hurricane.Hurricane;
+import edu.illinois.ncsa.incore.service.hazard.models.tornado.Tornado;
+import edu.illinois.ncsa.incore.service.hazard.models.tsunami.Tsunami;
 import org.json.simple.JSONObject;
 
 import javax.ws.rs.core.Response;
@@ -49,18 +53,71 @@ public class CommonUtil {
 
     public static Comparator<Earthquake> eqComparator(String sortBy, String order){
         // construct comparator
-        Comparator<Earthquake> comparator = (f1, f2) -> {
-            if (sortBy.equals("name")) {
-                return f1.getName().compareTo(f2.getName());
-            } else if (sortBy.equals("creator")){
-                return f1.getCreator().compareTo(f2.getCreator());
-                // default to date
-            } else{
-                return f1.getDate().compareTo(f2.getDate());
-            }
-        };
+        Comparator<Earthquake> comparator;
+        if (sortBy.equals("name")) {
+            comparator = Comparator.comparing(Earthquake::getName);
+        }
+        else{
+            // default to date
+            comparator = Comparator.comparing(Earthquake::getDate);
+        }
         if (order.equals("desc")) comparator = comparator.reversed();
+        return comparator;
+    }
 
+    public static Comparator<Flood> floodComparator(String sortBy, String order){
+        // construct comparator
+        Comparator<Flood> comparator;
+        if (sortBy.equals("name")) {
+            comparator = Comparator.comparing(Flood::getName);
+        }
+        else{
+            // default to date
+            comparator = Comparator.comparing(Flood::getDate);
+        }
+        if (order.equals("desc")) comparator = comparator.reversed();
+        return comparator;
+    }
+
+    public static Comparator<Hurricane> hurricaneComparator(String sortBy, String order){
+        // construct comparator
+        Comparator<Hurricane> comparator;
+        if (sortBy.equals("name")) {
+            comparator = Comparator.comparing(Hurricane::getName);
+        }
+        else{
+            // default to date
+            comparator = Comparator.comparing(Hurricane::getDate);
+        }
+        if (order.equals("desc")) comparator = comparator.reversed();
+        return comparator;
+    }
+
+    public static Comparator<Tornado> tornadoComparator(String sortBy, String order){
+        // construct comparator
+        Comparator<Tornado> comparator;
+        if (sortBy.equals("name")) {
+            comparator = Comparator.comparing(Tornado::getName);
+        }
+        else{
+            // default to date
+            comparator = Comparator.comparing(Tornado::getDate);
+        }
+        if (order.equals("desc")) comparator = comparator.reversed();
+        return comparator;
+    }
+
+    public static Comparator<Tsunami> tsunamiComparator(String sortBy, String order){
+        // construct comparator
+        Comparator<Tsunami> comparator;
+        if (sortBy.equals("name")) {
+            comparator = Comparator.comparing(Tsunami::getName);
+        }
+        else{
+            // default to date
+            comparator = Comparator.comparing(Tsunami::getDate);
+        }
+        if (order.equals("desc")) comparator = comparator.reversed();
         return comparator;
     }
 }

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/auth/LdapClient.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/auth/LdapClient.java
@@ -63,63 +63,61 @@ public class LdapClient {
 
     public Set<String> getUserGroups(String user) {
 
-//        long ldapRefreshSecs = 900;
-//        String ldapRefreshString = System.getenv("AUTH_LDAP_CACHE_REFRESH_SECS");
-//        if (ldapRefreshString != null && ldapRefreshString != "") {
-//            try {
-//                ldapRefreshSecs = Long.parseLong(ldapRefreshString);
-//            } catch (NumberFormatException e) {
-//                log.error("NumberFormatException when reading the system env variables: AUTH_LDAP_CACHE_REFRESH_SECS");
-//            }
-//        }
-//        long currSecs = System.currentTimeMillis() / 1000;
-//
-//        if (userGroupCache.containsKey(user)) {
-//            if (currSecs - userGroupCache.get(user).getLastUserRefresh() < ldapRefreshSecs) {
-//                return userGroupCache.get(user).getUserGroups();
-//            }
-//        }
-//
-//        Groups groupsInfo = new Groups();
-//        Set<String> result = new HashSet<>();
-//        try {
-//            DirContext ctx = getContext();
-//            SearchControls ctls = new SearchControls();
-//            String[] attrIDs = {"memberof"};
-//            ctls.setReturningAttributes(attrIDs);
-//            ctls.setSearchScope(SearchControls.ONELEVEL_SCOPE);
-//
-//            if (userDn == null) {
-//                log.error("No AUTH_LDAP_USER_DN in system env");
-//            }
-//
-//            NamingEnumeration answer = ctx.search(userDn, "(uid=" + user + ")", ctls);
-//            while (answer.hasMore()) {
-//                SearchResult rslt = (SearchResult) answer.next();
-//                Attributes attrs = rslt.getAttributes();
-//                String[] groupsDns = attrs.get("memberof").toString().split(", ");
-//
-//
-//                Set<String> groups = Arrays.stream(groupsDns)
-//                    .map(this::extractCnFromDn)
-//                    .collect(Collectors.toSet());
-//
-//                result.addAll(groups);
-//
-//            }
-//            ctx.close();
-//        } catch (NamingException e) {
-//            log.error("Could not find groups for user " + user, e);
-//        }
-//
-//        groupsInfo.setUserGroups(result);
-//        groupsInfo.setLastUserRefresh(System.currentTimeMillis() / 1000);
-//
-//        userGroupCache.put(user, groupsInfo);
-//
-//        return result;
-        Set<String> set =new HashSet<>(Arrays.asList("incore_user", "incore_admin", "prj_incore"));
-        return set;
+        long ldapRefreshSecs = 900;
+        String ldapRefreshString = System.getenv("AUTH_LDAP_CACHE_REFRESH_SECS");
+        if (ldapRefreshString != null && ldapRefreshString != "") {
+            try {
+                ldapRefreshSecs = Long.parseLong(ldapRefreshString);
+            } catch (NumberFormatException e) {
+                log.error("NumberFormatException when reading the system env variables: AUTH_LDAP_CACHE_REFRESH_SECS");
+            }
+        }
+        long currSecs = System.currentTimeMillis() / 1000;
+
+        if (userGroupCache.containsKey(user)) {
+            if (currSecs - userGroupCache.get(user).getLastUserRefresh() < ldapRefreshSecs) {
+                return userGroupCache.get(user).getUserGroups();
+            }
+        }
+
+        Groups groupsInfo = new Groups();
+        Set<String> result = new HashSet<>();
+        try {
+            DirContext ctx = getContext();
+            SearchControls ctls = new SearchControls();
+            String[] attrIDs = {"memberof"};
+            ctls.setReturningAttributes(attrIDs);
+            ctls.setSearchScope(SearchControls.ONELEVEL_SCOPE);
+
+            if (userDn == null) {
+                log.error("No AUTH_LDAP_USER_DN in system env");
+            }
+
+            NamingEnumeration answer = ctx.search(userDn, "(uid=" + user + ")", ctls);
+            while (answer.hasMore()) {
+                SearchResult rslt = (SearchResult) answer.next();
+                Attributes attrs = rslt.getAttributes();
+                String[] groupsDns = attrs.get("memberof").toString().split(", ");
+
+
+                Set<String> groups = Arrays.stream(groupsDns)
+                    .map(this::extractCnFromDn)
+                    .collect(Collectors.toSet());
+
+                result.addAll(groups);
+
+            }
+            ctx.close();
+        } catch (NamingException e) {
+            log.error("Could not find groups for user " + user, e);
+        }
+
+        groupsInfo.setUserGroups(result);
+        groupsInfo.setLastUserRefresh(System.currentTimeMillis() / 1000);
+
+        userGroupCache.put(user, groupsInfo);
+
+        return result;
 
     }
 

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/auth/LdapClient.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/auth/LdapClient.java
@@ -63,61 +63,63 @@ public class LdapClient {
 
     public Set<String> getUserGroups(String user) {
 
-        long ldapRefreshSecs = 900;
-        String ldapRefreshString = System.getenv("AUTH_LDAP_CACHE_REFRESH_SECS");
-        if (ldapRefreshString != null && ldapRefreshString != "") {
-            try {
-                ldapRefreshSecs = Long.parseLong(ldapRefreshString);
-            } catch (NumberFormatException e) {
-                log.error("NumberFormatException when reading the system env variables: AUTH_LDAP_CACHE_REFRESH_SECS");
-            }
-        }
-        long currSecs = System.currentTimeMillis() / 1000;
-
-        if (userGroupCache.containsKey(user)) {
-            if (currSecs - userGroupCache.get(user).getLastUserRefresh() < ldapRefreshSecs) {
-                return userGroupCache.get(user).getUserGroups();
-            }
-        }
-
-        Groups groupsInfo = new Groups();
-        Set<String> result = new HashSet<>();
-        try {
-            DirContext ctx = getContext();
-            SearchControls ctls = new SearchControls();
-            String[] attrIDs = {"memberof"};
-            ctls.setReturningAttributes(attrIDs);
-            ctls.setSearchScope(SearchControls.ONELEVEL_SCOPE);
-
-            if (userDn == null) {
-                log.error("No AUTH_LDAP_USER_DN in system env");
-            }
-
-            NamingEnumeration answer = ctx.search(userDn, "(uid=" + user + ")", ctls);
-            while (answer.hasMore()) {
-                SearchResult rslt = (SearchResult) answer.next();
-                Attributes attrs = rslt.getAttributes();
-                String[] groupsDns = attrs.get("memberof").toString().split(", ");
-
-
-                Set<String> groups = Arrays.stream(groupsDns)
-                    .map(this::extractCnFromDn)
-                    .collect(Collectors.toSet());
-
-                result.addAll(groups);
-
-            }
-            ctx.close();
-        } catch (NamingException e) {
-            log.error("Could not find groups for user " + user, e);
-        }
-
-        groupsInfo.setUserGroups(result);
-        groupsInfo.setLastUserRefresh(System.currentTimeMillis() / 1000);
-
-        userGroupCache.put(user, groupsInfo);
-
-        return result;
+//        long ldapRefreshSecs = 900;
+//        String ldapRefreshString = System.getenv("AUTH_LDAP_CACHE_REFRESH_SECS");
+//        if (ldapRefreshString != null && ldapRefreshString != "") {
+//            try {
+//                ldapRefreshSecs = Long.parseLong(ldapRefreshString);
+//            } catch (NumberFormatException e) {
+//                log.error("NumberFormatException when reading the system env variables: AUTH_LDAP_CACHE_REFRESH_SECS");
+//            }
+//        }
+//        long currSecs = System.currentTimeMillis() / 1000;
+//
+//        if (userGroupCache.containsKey(user)) {
+//            if (currSecs - userGroupCache.get(user).getLastUserRefresh() < ldapRefreshSecs) {
+//                return userGroupCache.get(user).getUserGroups();
+//            }
+//        }
+//
+//        Groups groupsInfo = new Groups();
+//        Set<String> result = new HashSet<>();
+//        try {
+//            DirContext ctx = getContext();
+//            SearchControls ctls = new SearchControls();
+//            String[] attrIDs = {"memberof"};
+//            ctls.setReturningAttributes(attrIDs);
+//            ctls.setSearchScope(SearchControls.ONELEVEL_SCOPE);
+//
+//            if (userDn == null) {
+//                log.error("No AUTH_LDAP_USER_DN in system env");
+//            }
+//
+//            NamingEnumeration answer = ctx.search(userDn, "(uid=" + user + ")", ctls);
+//            while (answer.hasMore()) {
+//                SearchResult rslt = (SearchResult) answer.next();
+//                Attributes attrs = rslt.getAttributes();
+//                String[] groupsDns = attrs.get("memberof").toString().split(", ");
+//
+//
+//                Set<String> groups = Arrays.stream(groupsDns)
+//                    .map(this::extractCnFromDn)
+//                    .collect(Collectors.toSet());
+//
+//                result.addAll(groups);
+//
+//            }
+//            ctx.close();
+//        } catch (NamingException e) {
+//            log.error("Could not find groups for user " + user, e);
+//        }
+//
+//        groupsInfo.setUserGroups(result);
+//        groupsInfo.setLastUserRefresh(System.currentTimeMillis() / 1000);
+//
+//        userGroupCache.put(user, groupsInfo);
+//
+//        return result;
+        Set<String> set =new HashSet<>(Arrays.asList("incore_user", "incore_admin", "prj_incore"));
+        return set;
 
     }
 


### PR DESCRIPTION
In this PR I added two query parameters `sortBy` and `order` for list and search endpoints of below. 
- `sortBy` is defaulted to be `date`. The other option tentatively implemented is "title"/"name"
- `order` is defaulted to be `desc` descending order. It also accepts `asc` ad ascending.

Endpoints:
- GET /hazard/api/earthquakes?sortBy=&order=
- GET /hazard/api/earthquakes/search?text=&sortBy=&order=
- GET /hazard/api/floods?sortBy=&order=
- GET /hazard/api/floods/search?text=&sortBy=&order=
- GET /hazard/api/hurricanes?sortBy=&order=
- GET /hazard/api/hurricanes/search?text=&sortBy=&order=
- GET /hazard/api/tsunamis?sortBy=&order=
- GET /hazard/api/tsunamis/search?text=&sortBy=&order=
- GET /hazard/api/tornadoes?sortBy=&order=
- GET /hazard/api/tornadoes/search?text=&sortBy=&order=
- 
- GET /data/api/datasets?sortBy=&order=
- GET /data/api/datasets/search?text=&sortBy=&order=
