### PR TITLE
Fixes 152 - Upgraded project and space-service dependencies: Jersey 3.1.2 and swagger 2.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- Upgraded project and space-service dependencies: Jersey 3.1.2 and swagger 2.1.12 for OpenAPI 3 [#152](https://github.com/IN-CORE/incore-services/issues/152)
+
 ## [1.14.0] -2023-06-14
 ### Added
 - Query parameters for sorting by given field in ascending and descending order [#111](https://github.com/IN-CORE/incore-services/issues/111)

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -157,19 +157,21 @@ test {
             implementation('org.dom4j:dom4j:2.1.1')
 
             //base jersey and jackson
-            implementation('javax.ws.rs:javax.ws.rs-api:2.1.1')
-            implementation('org.glassfish.jersey.core:jersey-server:2.31')
-            implementation('org.glassfish.jersey.containers:jersey-container-servlet:2.31')
-            implementation('org.glassfish.jersey.media:jersey-media-json-jackson:2.31')
-            implementation('org.glassfish.jersey.media:jersey-media-json-jackson:2.31')
-            implementation(group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart', version: '2.31')
-            implementation(group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.31')
+            implementation('org.glassfish.jersey.core:jersey-server:3.1.2')
+            implementation('org.glassfish.jersey.containers:jersey-container-servlet:3.1.2')
+            implementation('org.glassfish.jersey.media:jersey-media-json-jackson:3.1.2')
+            implementation(group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart', version: '3.1.2')
+            implementation(group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '3.1.2')
 
-            implementation(group: 'io.swagger', name: 'swagger-jersey2-jaxrs', version: '1.5.13')
+            // Swagger dependencies
+            implementation group: 'io.swagger.core.v3', name: 'swagger-annotations', version: '2.2.12'
+            implementation('io.swagger.core.v3:swagger-jaxrs2-jakarta:2.2.12')
+            implementation('io.swagger.core.v3:swagger-jaxrs2-servlet-initializer-jakarta:2.2.12')
+            implementation group: 'io.swagger.core.v3', name: 'swagger-jaxrs2', version: '2.2.12'
 
             // Libraries for testing jersey controller actions
-            testImplementation(group: 'org.glassfish.jersey.test-framework.providers', name: 'jersey-test-framework-provider-grizzly2', version: '2.31')
-            testImplementation(group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-servlet', version: '2.31')
+            testImplementation(group: 'org.glassfish.jersey.test-framework.providers', name: 'jersey-test-framework-provider-grizzly2', version: '3.1.2')
+            testImplementation(group: 'org.glassfish.jersey.containers', name: 'jersey-container-grizzly2-servlet', version: '3.1.2')
 
             // Temporary requirement for optional junit dependency that should not be optional
             testImplementation(group: 'org.apiguardian', name: 'apiguardian-api', version: '1.0.0')

--- a/server/incore-common/build.gradle
+++ b/server/incore-common/build.gradle
@@ -10,7 +10,6 @@ repositories {
 }
 
 dependencies {
-    testImplementation group: 'junit', name: 'junit', version: '4.12'
     implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5'
@@ -20,14 +19,12 @@ dependencies {
     implementation group: 'com.google.inject', name: 'guice', version: '3.0'
 
     //base jersey and jackson
-    implementation('javax.ws.rs:javax.ws.rs-api:2.1.1')
-    implementation('org.glassfish.jersey.core:jersey-server:2.31')
-    implementation('org.glassfish.jersey.containers:jersey-container-servlet:2.31')
-    implementation('org.glassfish.jersey.media:jersey-media-json-jackson:2.31')
-    implementation('org.glassfish.jersey.media:jersey-media-json-jackson:2.31')
-    implementation(group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart', version: '2.31')
-    implementation(group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '2.31')
+    implementation group: 'jakarta.ws.rs', name: 'jakarta.ws.rs-api', version: '3.1.0'
+    implementation('org.glassfish.jersey.core:jersey-server:3.1.2')
+    implementation('org.glassfish.jersey.containers:jersey-container-servlet:3.1.2')
+    implementation('org.glassfish.jersey.media:jersey-media-json-jackson:3.1.2')
+    implementation(group: 'org.glassfish.jersey.media', name: 'jersey-media-multipart', version: '3.1.2')
+    implementation(group: 'org.glassfish.jersey.inject', name: 'jersey-hk2', version: '3.1.2')
 
-    implementation(group: 'io.swagger', name: 'swagger-jersey2-jaxrs', version: '1.5.13')
-
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
 }

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/exceptions/IncoreHTTPException.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/exceptions/IncoreHTTPException.java
@@ -6,9 +6,9 @@
  *******************************************************************************/
 package edu.illinois.ncsa.incore.common.exceptions;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 /**
  * Runtime exception for applications.

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/GroupAllocations.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/GroupAllocations.java
@@ -14,9 +14,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.morphia.annotations.Entity;
 import dev.morphia.annotations.Id;
 import dev.morphia.annotations.Property;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import org.bson.types.ObjectId;
-
-import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 @Entity("GroupAllocations")

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/Space.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/Space.java
@@ -16,9 +16,9 @@ import dev.morphia.annotations.Id;
 import dev.morphia.annotations.Property;
 import edu.illinois.ncsa.incore.common.auth.PrivilegeLevel;
 import edu.illinois.ncsa.incore.common.auth.Privileges;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import org.bson.types.ObjectId;
 
-import javax.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/SpaceMetadata.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/SpaceMetadata.java
@@ -2,8 +2,7 @@ package edu.illinois.ncsa.incore.common.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.morphia.annotations.Embedded;
-
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 @Embedded

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/UserAllocations.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/UserAllocations.java
@@ -14,9 +14,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.morphia.annotations.Entity;
 import dev.morphia.annotations.Id;
 import dev.morphia.annotations.Property;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import org.bson.types.ObjectId;
-
-import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 @Entity("UserAllocations")

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/UserFinalQuota.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/UserFinalQuota.java
@@ -14,9 +14,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.morphia.annotations.Entity;
 import dev.morphia.annotations.Id;
 import dev.morphia.annotations.Property;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import org.bson.types.ObjectId;
-
-import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement
 @Entity("UserFinalQuota")

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/UserGroups.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/UserGroups.java
@@ -14,9 +14,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.morphia.annotations.Entity;
 import dev.morphia.annotations.Id;
 import dev.morphia.annotations.Property;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import org.bson.types.ObjectId;
 
-import javax.xml.bind.annotation.XmlRootElement;
 import java.util.List;
 
 @XmlRootElement

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/AllocationUtils.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/AllocationUtils.java
@@ -17,9 +17,7 @@ import edu.illinois.ncsa.incore.common.models.UserAllocations;
 import edu.illinois.ncsa.incore.common.models.UserFinalQuota;
 import edu.illinois.ncsa.incore.common.models.UserUsages;
 import edu.illinois.ncsa.incore.common.dao.IUserAllocationsRepository;
-
-
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public class AllocationUtils {
 

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/JsonUtils.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/JsonUtils.java
@@ -6,6 +6,7 @@ import edu.illinois.ncsa.incore.common.dao.IUserFinalQuotaRepository;
 import edu.illinois.ncsa.incore.common.exceptions.IncoreHTTPException;
 import edu.illinois.ncsa.incore.common.dao.IUserAllocationsRepository;
 import edu.illinois.ncsa.incore.common.models.*;
+import jakarta.ws.rs.core.Response;
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -13,7 +14,6 @@ import org.json.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
-import javax.ws.rs.core.Response;
 import java.util.LinkedList;
 import java.util.List;
 

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/UserGroupUtils.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/UserGroupUtils.java
@@ -3,8 +3,8 @@ package edu.illinois.ncsa.incore.common.utils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.illinois.ncsa.incore.common.exceptions.IncoreHTTPException;
 import edu.illinois.ncsa.incore.common.models.HeadersUserGroups;
+import jakarta.ws.rs.core.Response;
 
-import javax.ws.rs.core.Response;
 import java.util.List;
 
 public class UserGroupUtils {

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/UserInfoUtils.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/UserInfoUtils.java
@@ -3,8 +3,7 @@ package edu.illinois.ncsa.incore.common.utils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.illinois.ncsa.incore.common.exceptions.IncoreHTTPException;
 import edu.illinois.ncsa.incore.common.models.UserInfo;
-
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 public class UserInfoUtils {
 

--- a/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/CorsFilter.java
+++ b/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/CorsFilter.java
@@ -11,10 +11,11 @@
 package edu.illinois.ncsa.incore.service.space;
 
 
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.MultivaluedMap;
+
 import java.io.IOException;
 
 public class CorsFilter implements ContainerResponseFilter {

--- a/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/GenericExceptionMapper.java
+++ b/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/GenericExceptionMapper.java
@@ -10,12 +10,11 @@
 
 package edu.illinois.ncsa.incore.service.space;
 
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
 import org.apache.log4j.Logger;
-
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-import javax.ws.rs.ext.Provider;
 
 
 /**

--- a/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/controllers/AllocationsController.java
+++ b/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/controllers/AllocationsController.java
@@ -14,21 +14,24 @@ import edu.illinois.ncsa.incore.common.dao.IGroupAllocationsRepository;
 import edu.illinois.ncsa.incore.common.dao.IUserFinalQuotaRepository;
 import edu.illinois.ncsa.incore.common.exceptions.IncoreHTTPException;
 import edu.illinois.ncsa.incore.common.utils.JsonUtils;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.log4j.Logger;
 import org.json.JSONObject;
 import org.json.simple.parser.ParseException;
 
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 /**
  * Created by ywkim on 3/14/2022.
  */
-
-@SwaggerDefinition(
+@OpenAPIDefinition(
     info = @Info(
         description = "IN-CORE Allocations Service for getting the user's allocation information.",
         version = "v0.1",
@@ -42,20 +45,13 @@ import javax.ws.rs.core.Response;
             name = "Mozilla Public License 2.0 (MPL 2.0)",
             url = "https://www.mozilla.org/en-US/MPL/2.0/"
         )
-    ),
-    consumes = {"application/json"},
-    produces = {"application/json"},
-    schemes = {SwaggerDefinition.Scheme.HTTP}
+    )
+//    consumes = {"application/json"},
+//    produces = {"application/json"},
+//    schemes = {SwaggerDefinition.Scheme.HTTP}
 
 )
-
-@Api(value = "allocations", authorizations = {})
-
 @Path("allocations")
-@ApiResponses(value = {
-    @ApiResponse(code = 500, message = "Internal Server Error")
-})
-
 public class AllocationsController {
     @Inject
     private IGroupAllocationsRepository allocationsRepository;
@@ -67,8 +63,8 @@ public class AllocationsController {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gives the allocation and can be used as status check as well.",
-        notes = "This will provide the allocation of the logged in user.")
+    @Operation(summary = "Gives the allocation and can be used as status check as well.",
+        description = "This will provide the allocation of the logged in user.")
     public String getUsage(@HeaderParam("x-auth-userinfo") String userInfo) {
         JSONObject outJson = null;
 
@@ -86,12 +82,12 @@ public class AllocationsController {
     @GET
     @Path("users/{username}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gives the allocation status of the given username.",
-        notes = "This will only work for admin user group.")
+    @Operation(summary = "Gives the allocation status of the given username.",
+        description = "This will only work for admin user group.")
     public String getAllocationsByUsername(
         @HeaderParam("x-auth-userinfo") String userInfo,
         @HeaderParam("x-auth-usergroup") String userGroup,
-        @ApiParam(value = "Dataset Id from data service", required = true) @PathParam("username") String userId) {
+        @Parameter(name = "Dataset Id from data service", required = true) @PathParam("username") String userId) {
         // check if the logged in user is in admin group
         Boolean isAdmin = JsonUtils.isLoggedInUserAdmin(userGroup);
 
@@ -115,12 +111,12 @@ public class AllocationsController {
     @GET
     @Path("groups/{groupname}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gives the allocation status of the given group name.",
-        notes = "This will only work for admin user group.")
+    @Operation(summary = "Gives the allocation status of the given group name.",
+        description = "This will only work for admin user group.")
     public String getAllocationsByGroupname(
         @HeaderParam("x-auth-userinfo") String userInfo,
         @HeaderParam("x-auth-usergroup") String userGroup,
-        @ApiParam(value = "Dataset Id from data service", required = true) @PathParam("groupname") String groupId) {
+        @Parameter(name = "Dataset Id from data service", required = true) @PathParam("groupname") String groupId) {
         // check if the logged in user is in admin group
         Boolean isAdmin = JsonUtils.isLoggedInUserAdmin(userGroup);
 

--- a/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/controllers/SpaceController.java
+++ b/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/controllers/SpaceController.java
@@ -19,14 +19,20 @@ import edu.illinois.ncsa.incore.common.utils.JsonUtils;
 import edu.illinois.ncsa.incore.common.utils.UserGroupUtils;
 import edu.illinois.ncsa.incore.common.utils.UserInfoUtils;
 import edu.illinois.ncsa.incore.service.space.models.Members;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.log4j.Logger;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -41,7 +47,7 @@ import java.util.stream.Collectors;
  * Created by ywkim on 7/26/2017.
  */
 
-@SwaggerDefinition(
+@OpenAPIDefinition(
     info = @Info(
         description = "IN-CORE Space Service for creating and accessing spaces",
         version = "v0.6.3",
@@ -55,14 +61,35 @@ import java.util.stream.Collectors;
             name = "Mozilla Public License 2.0 (MPL 2.0)",
             url = "https://www.mozilla.org/en-US/MPL/2.0/"
         )
-    ),
-    consumes = {"application/json"},
-    produces = {"application/json"},
-    schemes = {SwaggerDefinition.Scheme.HTTP}
-
+    )
+//    consumes = {"application/json"},
+//    produces = {"application/json"},
+//    schemes = {OpenAPIDefinition.HTTP}
 )
+//@SwaggerDefinition(
+//    info = @Info(
+//        description = "IN-CORE Space Service for creating and accessing spaces",
+//        version = "v0.6.3",
+//        title = "IN-CORE v2 Space Service API",
+//        contact = @Contact(
+//            name = "IN-CORE Dev Team",
+//            email = "incore-dev@lists.illinois.edu",
+//            url = "https://incore.ncsa.illinois.edu"
+//        ),
+//        license = @License(
+//            name = "Mozilla Public License 2.0 (MPL 2.0)",
+//            url = "https://www.mozilla.org/en-US/MPL/2.0/"
+//        )
+//    ),
+//    consumes = {"application/json"},
+//    produces = {"application/json"},
+//    schemes = {SwaggerDefinition.Scheme.HTTP}
+//
+//)
+//@Api(value = "spaces", authorizations = {})
 
-@Api(value = "spaces", authorizations = {})
+// Not sure if @Tag is equivalent to @Apis
+@Tag(name = "spaces")
 
 @Path("spaces")
 public class SpaceController {
@@ -98,8 +125,8 @@ public class SpaceController {
 
     @Inject
     public SpaceController(
-        @ApiParam(value = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
-        @ApiParam(value = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups
+        @Parameter(name = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
+        @Parameter(name = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups
     ) {
         this.userGroups = userGroups;
         this.username = UserInfoUtils.getUsername(userInfo);
@@ -109,9 +136,9 @@ public class SpaceController {
     @POST
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Ingest space object as json")
+    @Operation(description = "Ingest space object as json")
     public Space ingestSpace(
-        @ApiParam(value = "JSON representing an input space", required = true) @FormDataParam("space") String spaceJson) {
+        @Parameter(name = "JSON representing an input space", required = true) @FormDataParam("space") String spaceJson) {
 
         ObjectMapper spaceObjectMapper = new ObjectMapper();
         try {
@@ -145,11 +172,12 @@ public class SpaceController {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gets the list of all available spaces", notes = "For member parameter, it will return spaces that the user " +
+    @Operation(summary = "Gets the list of all available spaces", description = "For member parameter, it will return spaces that the " +
+        "user " +
         "has read/write/admin privileges on. If a member Id is passed, it will return all spaces that contains the member. For name " +
         "parameter, it will return the space id with the given space name.")
-    public List<Space> getSpacesList(@ApiParam(value = "Member Id") @QueryParam("member") String memberId,
-                                     @ApiParam(value = "Space Name") @QueryParam("name") String spaceName) {
+    public List<Space> getSpacesList(@Parameter(name = "Member Id") @QueryParam("member") String memberId,
+                                     @Parameter(name = "Space Name") @QueryParam("name") String spaceName) {
 
         if (memberId != null) {
             if (!authorizer.canUserReadMember(this.username, memberId, spaceRepository.getAllSpaces(), this.groups)) {
@@ -183,8 +211,8 @@ public class SpaceController {
     @GET
     @Path("{id}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gets a space.")
-    public Space getSpaceById(@ApiParam(value = "Space id", required = true) @PathParam("id") String spaceId) {
+    @Operation(description = "Gets a space.")
+    public Space getSpaceById(@Parameter(name = "Space id", required = true) @PathParam("id") String spaceId) {
 
         Space space = getSpace(spaceId);
 
@@ -200,10 +228,10 @@ public class SpaceController {
     @Path("{id}")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Updates a space.")
-    public Space updateSpace(@ApiParam(value = "Space id.", required = true) @PathParam("id") String spaceId,
-                             @ApiParam(value = "JSON representing a space") @FormDataParam("space") String spaceJson,
-                             @ApiParam(value = "JSON representing a members list for removing from space") @FormDataParam("remove") String membersToRemoveJson) {
+    @Operation(description = "Updates a space.")
+    public Space updateSpace(@Parameter(name = "Space id.", required = true) @PathParam("id") String spaceId,
+                             @Parameter(name = "JSON representing a space") @FormDataParam("space") String spaceJson,
+                             @Parameter(name = "JSON representing a members list for removing from space") @FormDataParam("remove") String membersToRemoveJson) {
         Space space = getSpace(spaceId);
 
         //modify space by changing name or adding a list of members
@@ -280,10 +308,10 @@ public class SpaceController {
     @POST
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{id}/members/{memberId}")
-    @ApiOperation(value = "Adds a member to a space")
+    @Operation(description = "Adds a member to a space")
     public Space addMembersToSpace(
-        @ApiParam(value = "Space Id", required = true) @PathParam("id") String spaceId,
-        @ApiParam(value = "Member Id", required = true) @PathParam("memberId") String memberId) {
+        @Parameter(name = "Space Id", required = true) @PathParam("id") String spaceId,
+        @Parameter(name = "Member Id", required = true) @PathParam("memberId") String memberId) {
         Space space = getSpace(spaceId);
 
         if (!authorizer.canWrite(this.username, space.getPrivileges(), this.groups)) {
@@ -302,10 +330,10 @@ public class SpaceController {
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{id}/grant")
-    @ApiOperation(value = "Grants new privileges to a space")
+    @Operation(description = "Grants new privileges to a space")
     public Space grantPrivilegesToSpace(
-        @ApiParam(value = "Space Id", required = true) @PathParam("id") String spaceId,
-        @ApiParam(value = "JSON representing a privilege block", required = true) @FormDataParam("grant") String privilegesJson) {
+        @Parameter(name = "Space Id", required = true) @PathParam("id") String spaceId,
+        @Parameter(name = "JSON representing a privilege block", required = true) @FormDataParam("grant") String privilegesJson) {
         Space space = getSpace(spaceId);
 
         if (!authorizer.canWrite(this.username, space.getPrivileges(), this.groups)) {
@@ -329,10 +357,10 @@ public class SpaceController {
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{id}/members/{memberId}")
-    @ApiOperation("Removes a member from a space")
+    @Operation(description = "Removes a member from a space")
     public Space removeMemberFromSpace(
-        @ApiParam(value = "Space id", required = true) @PathParam("id") String spaceId,
-        @ApiParam(value = "Member id", required = true) @PathParam("memberId") String memberId) {
+        @Parameter(name = "Space id", required = true) @PathParam("id") String spaceId,
+        @Parameter(name = "Member id", required = true) @PathParam("memberId") String memberId) {
 
         if (memberId == null) {
             throw new IncoreHTTPException(Response.Status.BAD_REQUEST, "User must provide a member Id or a list of member ids");

--- a/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/controllers/UsageController.java
+++ b/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/controllers/UsageController.java
@@ -11,7 +11,17 @@
 package edu.illinois.ncsa.incore.service.space.controllers;
 
 import edu.illinois.ncsa.incore.common.exceptions.IncoreHTTPException;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.log4j.Logger;
 import org.json.JSONObject;
 import org.json.simple.parser.ParseException;
@@ -19,16 +29,11 @@ import edu.illinois.ncsa.incore.common.dao.IUserAllocationsRepository;
 import edu.illinois.ncsa.incore.common.dao.IUserFinalQuotaRepository;
 import edu.illinois.ncsa.incore.common.utils.JsonUtils;
 
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 /**
  * Created by ywkim on 3/14/2022.
  */
 
-@SwaggerDefinition(
+@OpenAPIDefinition(
     info = @Info(
         description = "IN-CORE Usage Service for getting the user's usage information.",
         version = "v0.1",
@@ -42,19 +47,40 @@ import javax.ws.rs.core.Response;
             name = "Mozilla Public License 2.0 (MPL 2.0)",
             url = "https://www.mozilla.org/en-US/MPL/2.0/"
         )
-    ),
-    consumes = {"application/json"},
-    produces = {"application/json"},
-    schemes = {SwaggerDefinition.Scheme.HTTP}
+    )
+//    consumes = {"application/json"},
+//    produces = {"application/json"},
+//    schemes = {SwaggerDefinition.Scheme.HTTP}
 
 )
+//@SwaggerDefinition(
+//    info = @Info(
+//        description = "IN-CORE Usage Service for getting the user's usage information.",
+//        version = "v0.1",
+//        title = "IN-CORE v2 Usage Service API",
+//        contact = @Contact(
+//            name = "IN-CORE Dev Team",
+//            email = "incore-dev@lists.illinois.edu",
+//            url = "https://incore.ncsa.illinois.edu"
+//        ),
+//        license = @License(
+//            name = "Mozilla Public License 2.0 (MPL 2.0)",
+//            url = "https://www.mozilla.org/en-US/MPL/2.0/"
+//        )
+//    ),
+//    consumes = {"application/json"},
+//    produces = {"application/json"},
+//    schemes = {SwaggerDefinition.Scheme.HTTP}
+//
+//)
 
-@Api(value = "usage", authorizations = {})
+@Tag(name = "usage")
+//@Api(value = "usage", authorizations = {})
 
 @Path("usage")
-@ApiResponses(value = {
-    @ApiResponse(code = 500, message = "Internal Server Error")
-})
+//@ApiResponses(value = {
+//    @ApiResponse(code = 500, message = "Internal Server Error")
+//})
 
 public class UsageController {
     @Inject
@@ -67,8 +93,8 @@ public class UsageController {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gives the usage status and can be used as status check as well.",
-        notes = "This will provide the usage of the logged in user.")
+    @Operation(summary = "Gives the usage status and can be used as status check as well.",
+        description = "This will provide the usage of the logged in user.")
     public String getUsage(@HeaderParam("x-auth-userinfo") String userInfo) {
         JSONObject outJson = null;
 
@@ -86,12 +112,12 @@ public class UsageController {
     @GET
     @Path("{username}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gives the usage status of the given username.",
-        notes = "This will only work for admin user group.")
+    @Operation(summary = "Gives the usage status of the given username.",
+        description = "This will only work for admin user group.")
     public String getUsageByUsername(
         @HeaderParam("x-auth-userinfo") String userInfo,
         @HeaderParam("x-auth-usergroup") String userGroup,
-        @ApiParam(value = "Dataset Id from data service", required = true) @PathParam("username") String userId) {
+        @Parameter(name = "Dataset Id from data service", required = true) @PathParam("username") String userId) {
         // check if the logged in user is in admin group
         Boolean isAdmin = JsonUtils.isLoggedInUserAdmin(userGroup);
 

--- a/server/space-service/src/main/webapp/WEB-INF/web.xml
+++ b/server/space-service/src/main/webapp/WEB-INF/web.xml
@@ -8,15 +8,23 @@
         <servlet-name>Jersey Web Application</servlet-name>
         <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
         <init-param>
-            <param-name>javax.ws.rs.Application</param-name>
+            <param-name>jersey.config.server.wadl.disableWadl</param-name>
+            <param-value>true</param-value>
+        </init-param>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
             <param-value>edu.illinois.ncsa.incore.service.space.Application</param-value>
         </init-param>
         <init-param>
             <param-name>jersey.config.server.provider.packages</param-name>
             <param-value>
-                edu.illinois.ncsa.incore.service.space.controllers,
-                io.swagger.jaxrs.listing
+                edu.illinois.ncsa.incore.service.space.controllers
+                io.swagger.v3.jaxrs2.integration.resources
             </param-value>
+        </init-param>
+        <init-param>
+            <param-name>openApi.configuration.prettyPrint</param-name>
+            <param-value>true</param-value>
         </init-param>
         <init-param>
             <param-name>jersey.config.server.provider.classnames</param-name>
@@ -32,16 +40,25 @@
     </servlet-mapping>
 
     <servlet>
-        <servlet-name>Jersey2Config</servlet-name>
-        <servlet-class>io.swagger.jersey.config.JerseyJaxrsConfig</servlet-class>
-        <init-param>
-            <param-name>api.version</param-name>
-            <param-value>1.2.1</param-value>
-        </init-param>
-        <init-param>
-            <param-name>swagger.api.basepath</param-name>
-            <param-value>/space/api</param-value>
-        </init-param>
-        <load-on-startup>2</load-on-startup>
+        <servlet-name>OpenApi</servlet-name>
+        <servlet-class>io.swagger.v3.jaxrs2.integration.OpenApiServlet</servlet-class>
     </servlet>
+
+    <servlet-mapping>
+        <servlet-name>OpenApi</servlet-name>
+        <url-pattern>/openapi/*</url-pattern>
+    </servlet-mapping>
+    <!--    <servlet>-->
+    <!--        <servlet-name>Jersey2Config</servlet-name>-->
+    <!--    <servlet-class>io.swagger.jersey.config.JerseyJaxrsConfig</servlet-class>-->
+    <!--        <init-param>-->
+    <!--            <param-name>api.version</param-name>-->
+    <!--            <param-value>1.2.1</param-value>-->
+    <!--        </init-param>-->
+    <!--        <init-param>-->
+    <!--            <param-name>swagger.api.basepath</param-name>-->
+    <!--            <param-value>/space/api</param-value>-->
+    <!--        </init-param>-->
+    <!--        <load-on-startup>2</load-on-startup>-->
+    <!--    </servlet>-->
 </web-app>

--- a/server/space-service/src/test/java/edu/illinois/ncsa/incore/service/space/controllers/SpaceControllerTest.java
+++ b/server/space-service/src/test/java/edu/illinois/ncsa/incore/service/space/controllers/SpaceControllerTest.java
@@ -10,6 +10,8 @@
 
 package edu.illinois.ncsa.incore.service.space.controllers;
 
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
 import mocks.MockApplication;
 import org.apache.commons.io.IOUtils;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
@@ -20,8 +22,6 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;


### PR DESCRIPTION
This is branched off @jonglee1's branch to upgrade gradle to 8 and gretty to 4. Jong's upgrade broke at runtime because gretty brings in Jakarta. I added the necessary libaries to upgrade Jersey to 3.1.2 and Swagger to OpenAPI 3 and I fixed just the space service and the incore-common package since it's dependent.

If you do ./gradlew farmRun - this won't work because everything else is broken. You can test JUST the space service doing the following:

```
./gradlew clean
./gradlew space-service:test  (runs unit test)
./gradlew space-service:appStart  (starts the space-service)
```

Once you start the service, you can see the new swagger doc by pointing your browser here:
http://localhost:8080/space/api/openapi.json

You can test the local service with:

```
curl -i -X GET \
   -H "x-auth-userinfo:{\"preferred_username\":\"user_name\"}" \
   -H "x-auth-usergroup:{\"groups\":[\"some_group\"]}" \
 'http://localhost:8080/space/api/allocations'
```

Replace username with your username and some_group with something like admin group