### PR TITLE
167 update semantics service to use jersey 3 and open api 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Refactor AllocationsController and UsageController to use updated authorizer [#143](https://github.com/IN-CORE/incore-services/issues/143)
 - Upgraded project and space-service dependencies: Jersey 3.1.2 and swagger 2.1.12 for OpenAPI 3 [#152](https://github.com/IN-CORE/incore-services/issues/152)
+- Upgraded project and semantics-service dependencies: Jersey 3.1.2 and swagger 2.1.12 for OpenAPI 3 [#167](https://github.com/IN-CORE/incore-services/issues/167)
 
 ## [1.14.0] -2023-06-14
 ### Added

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -173,7 +173,6 @@ test {
             implementation("io.swagger.core.v3:swagger-annotations:$swaggerVersion")
             implementation("io.swagger.core.v3:swagger-jaxrs2-jakarta:$swaggerVersion")
             implementation("io.swagger.core.v3:swagger-jaxrs2-servlet-initializer-jakarta:$swaggerVersion")
-            implementation("io.swagger.core.v3:swagger-jaxrs2:$swaggerVersion")
 
             // Libraries for testing jersey controller actions
             testImplementation("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:$jerseyVersion")

--- a/server/semantics-service/build.gradle
+++ b/server/semantics-service/build.gradle
@@ -3,9 +3,8 @@ gretty {
     contextPath '/semantics/'
 }
 
-// TODO investigate if we really need semantics core or not
-//dependencies {
-//    implementation group: 'org.apache.jena', name: 'jena-core', version: '3.1.1'
-//    implementation project(':semantic-core')
-//}
+dependencies {
+    implementation group: 'org.apache.jena', name: 'jena-core', version: '3.1.1'
+    implementation project(':semantic-core')
+}
 

--- a/server/semantics-service/build.gradle
+++ b/server/semantics-service/build.gradle
@@ -3,8 +3,9 @@ gretty {
     contextPath '/semantics/'
 }
 
-dependencies {
-    implementation group: 'org.apache.jena', name: 'jena-core', version: '3.1.1'
-    implementation project(':semantic-core')
-}
+// TODO investigate if we really need semantics core or not
+//dependencies {
+//    implementation group: 'org.apache.jena', name: 'jena-core', version: '3.1.1'
+//    implementation project(':semantic-core')
+//}
 

--- a/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/CorsFilter.java
+++ b/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/CorsFilter.java
@@ -1,9 +1,9 @@
 package edu.illinois.ncsa.incore.service.semantics;
 
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.MultivaluedMap;
 
 public class CorsFilter implements ContainerResponseFilter {
     @Override

--- a/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/JerseyMapperProvider.java
+++ b/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/JerseyMapperProvider.java
@@ -11,8 +11,8 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import edu.illinois.ncsa.incore.semantic.units.io.serializer.json.JsonUnitSerializer;
 import edu.illinois.ncsa.incore.semantic.units.model.Unit;
 
-import javax.ws.rs.ext.ContextResolver;
-import javax.ws.rs.ext.Provider;
+import jakarta.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.ext.Provider;
 
 @Provider
 public class JerseyMapperProvider implements ContextResolver<ObjectMapper> {

--- a/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/controllers/StatusController.java
+++ b/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/controllers/StatusController.java
@@ -6,10 +6,10 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.apache.log4j.Logger;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 @Api(value = "status", authorizations = {})
 

--- a/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/controllers/StatusController.java
+++ b/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/controllers/StatusController.java
@@ -1,9 +1,11 @@
 package edu.illinois.ncsa.incore.service.semantics.controllers;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.log4j.Logger;
 
 import jakarta.ws.rs.GET;
@@ -11,19 +13,33 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
-@Api(value = "status", authorizations = {})
+@OpenAPIDefinition(
+    info = @Info(
+        description = "IN-CORE Semantics Services for type and data type",
+        version = "v0.6.3",
+        title = "IN-CORE v2 Semantics Service API",
+        contact = @Contact(
+            name = "IN-CORE Dev Team",
+            email = "incore-dev@lists.illinois.edu",
+            url = "https://incore.ncsa.illinois.edu"
+        ),
+        license = @License(
+            name = "Mozilla Public License 2.0 (MPL 2.0)",
+            url = "https://www.mozilla.org/en-US/MPL/2.0/"
+        )
+    )
+)
+
+@Tag(name = "status")
 
 @Path("status")
-@ApiResponses(value = {
-    @ApiResponse(code = 500, message = "Internal Server Error")
-})
 public class StatusController {
     private static final Logger logger = Logger.getLogger(StatusController.class);
 
     @GET
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Gives the status of the service.",
-        notes = "This will provide the status of the service as a JSON.")
+    @Operation(summary = "Gives the status of the service.",
+        description = "This will provide the status of the service as a JSON.")
     public String getStatus() {
         String statusJson = "{\"status\": \"responding\"}";
         return statusJson;

--- a/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/controllers/TypeController.java
+++ b/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/controllers/TypeController.java
@@ -7,7 +7,13 @@ import edu.illinois.ncsa.incore.common.models.Space;
 import edu.illinois.ncsa.incore.common.utils.UserGroupUtils;
 import edu.illinois.ncsa.incore.common.utils.UserInfoUtils;
 import edu.illinois.ncsa.incore.service.semantics.daos.ITypeDAO;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.bson.Document;
 
 import jakarta.inject.Inject;
@@ -17,8 +23,7 @@ import jakarta.ws.rs.core.Response;
 import java.util.*;
 import java.util.stream.Collectors;
 
-// @SwaggerDefinition is common for all the service's controllers and can be put in any one of them
-@SwaggerDefinition(
+@OpenAPIDefinition(
     info = @Info(
         description = "IN-CORE Semantics Services for type and data type",
         version = "v0.6.3",
@@ -32,13 +37,10 @@ import java.util.stream.Collectors;
             name = "Mozilla Public License 2.0 (MPL 2.0)",
             url = "https://www.mozilla.org/en-US/MPL/2.0/"
         )
-    ),
-    consumes = {"application/json"},
-    produces = {"application/json"},
-    schemes = {SwaggerDefinition.Scheme.HTTP}
+    )
 )
 
-@Api(value = "types", authorizations = {})
+@Tag(name = "types")
 
 @Path("")
 public class TypeController {
@@ -56,8 +58,8 @@ public class TypeController {
 
     @Inject
     public TypeController(
-        @ApiParam(value = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
-        @ApiParam(value = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups
+        @Parameter(name = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
+        @Parameter(name = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups
     ) {
         this.username = UserInfoUtils.getUsername(userInfo);
         this.groups = UserGroupUtils.getUserGroups(userGroups);
@@ -71,7 +73,7 @@ public class TypeController {
     @GET
     @Path("types")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "list all types belong user has access to.")
+    @Operation(summary = "list all types belong user has access to.")
     public Response listTypes() {
         List<Document> typeList = this.typeDAO.getTypes();
         Set<String> userMembersSet = authorizer.getAllMembersUserHasReadAccessTo(username, spaceRepository.getAllSpaces(), groups);
@@ -88,10 +90,10 @@ public class TypeController {
     @GET
     @Path("types/{uri}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Show specific types by uri.")
+    @Operation(summary = "Show specific types by uri.")
     public Response getType(
-        @ApiParam(value = "Type uri (name).", required = true) @PathParam("uri") String uri,
-        @ApiParam(value = "version number.") @QueryParam("version") String version) {
+        @Parameter(name = "Type uri (name).", required = true) @PathParam("uri") String uri,
+        @Parameter(name = "version number.") @QueryParam("version") String version) {
         if (version == null) {
             version = "latest";
         }
@@ -131,9 +133,9 @@ public class TypeController {
     @GET
     @Path("types/search")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Search type by partial match of text.")
+    @Operation(summary = "Search type by partial match of text.")
     public Response searchType(
-        @ApiParam(value = "Type uri (name).") @QueryParam("text") String text) {
+        @Parameter(name = "Type uri (name).") @QueryParam("text") String text) {
         Set<String> userMembersSet = authorizer.getAllMembersUserHasReadAccessTo(username, spaceRepository.getAllSpaces(), groups);
 
         Optional<List<Document>> typeList = this.typeDAO.searchType(text);
@@ -154,9 +156,9 @@ public class TypeController {
     @Path("/types")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Publish new type.")
+    @Operation(summary = "Publish new type.")
     public Response publishType(
-        @ApiParam(value = "Type uri (name).") Document type) {
+        @Parameter(name = "Type uri (name).") Document type) {
         Space space = spaceRepository.getSpaceByName(this.username);
 
         String id = this.typeDAO.postType(type);
@@ -173,9 +175,9 @@ public class TypeController {
     @DELETE
     @Path("types/{id}")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Delete type by id.")
+    @Operation(summary = "Delete type by id.")
     public Response deleteType(
-        @ApiParam(value = "Type id.") @PathParam("id") String id) {
+        @Parameter(name = "Type id.") @PathParam("id") String id) {
         String deletedId = this.typeDAO.deleteType(id);
         if (deletedId == null) {
             throw new IncoreHTTPException(Response.Status.NOT_FOUND, "Could not find type with id " + id);

--- a/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/controllers/TypeController.java
+++ b/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/controllers/TypeController.java
@@ -10,10 +10,10 @@ import edu.illinois.ncsa.incore.service.semantics.daos.ITypeDAO;
 import io.swagger.annotations.*;
 import org.bson.Document;
 
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.*;
 import java.util.stream.Collectors;
 

--- a/server/semantics-service/src/main/webapp/WEB-INF/web.xml
+++ b/server/semantics-service/src/main/webapp/WEB-INF/web.xml
@@ -8,15 +8,23 @@
         <servlet-name>Jersey Web Application</servlet-name>
         <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
         <init-param>
-            <param-name>javax.ws.rs.Application</param-name>
+            <param-name>jersey.config.server.wadl.disableWadl</param-name>
+            <param-value>true</param-value>
+        </init-param>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
             <param-value>edu.illinois.ncsa.incore.service.semantics.Application</param-value>
         </init-param>
         <init-param>
             <param-name>jersey.config.server.provider.packages</param-name>
             <param-value>
-                edu.illinois.ncsa.incore.service.semantics.controllers,
-                io.swagger.jaxrs.listing
+                edu.illinois.ncsa.incore.service.semantics.controllers
+                io.swagger.v3.jaxrs2.integration.resources
             </param-value>
+        </init-param>
+        <init-param>
+            <param-name>openApi.configuration.prettyPrint</param-name>
+            <param-value>true</param-value>
         </init-param>
         <init-param>
             <param-name>jersey.config.server.provider.classnames</param-name>
@@ -32,16 +40,12 @@
     </servlet-mapping>
 
     <servlet>
-        <servlet-name>Jersey2Config</servlet-name>
-        <servlet-class>io.swagger.jersey.config.JerseyJaxrsConfig</servlet-class>
-        <init-param>
-            <param-name>api.version</param-name>
-            <param-value>1.2.1</param-value>
-        </init-param>
-        <init-param>
-            <param-name>swagger.api.basepath</param-name>
-            <param-value>/data/api</param-value>
-        </init-param>
-        <load-on-startup>2</load-on-startup>
+        <servlet-name>OpenApi</servlet-name>
+        <servlet-class>io.swagger.v3.jaxrs2.integration.OpenApiServlet</servlet-class>
     </servlet>
+
+    <servlet-mapping>
+        <servlet-name>OpenApi</servlet-name>
+        <url-pattern>/openapi/*</url-pattern>
+    </servlet-mapping>
 </web-app>

--- a/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/models/Members.java
+++ b/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/models/Members.java
@@ -2,7 +2,7 @@ package edu.illinois.ncsa.incore.service.space.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
 import java.util.ArrayList;
 import java.util.List;
 


### PR DESCRIPTION
Test these two endpoints:

GET http://localhost:8080/semantics/api/types
GET http://localhost:8080/semantics/api/types/incore:roadwayFragilityMapping

with admin presented in x-auth-usergroup
e.g. {"groups": ["incore_user", "incore_coe", "incore_admin"]}