### PR TITLE
163 update hazard service to use jersey 3 and open api 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Refactor AllocationsController and UsageController to use updated authorizer [#143](https://github.com/IN-CORE/incore-services/issues/143)
 - Upgraded project and space-service dependencies: Jersey 3.1.2 and swagger 2.1.12 for OpenAPI 3 [#152](https://github.com/IN-CORE/incore-services/issues/152)
+- Upgraded project and hazard-service dependencies: Jersey 3.1.2 and swagger 2.1.12 for OpenAPI 3 [#163](https://github.com/IN-CORE/incore-services/issues/163)
 
 ## [1.14.0] -2023-06-14
 ### Added

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -173,7 +173,7 @@ test {
             implementation("io.swagger.core.v3:swagger-annotations:$swaggerVersion")
             implementation("io.swagger.core.v3:swagger-jaxrs2-jakarta:$swaggerVersion")
             implementation("io.swagger.core.v3:swagger-jaxrs2-servlet-initializer-jakarta:$swaggerVersion")
-            implementation("io.swagger.core.v3:swagger-jaxrs2:$swaggerVersion")
+//            implementation("io.swagger.core.v3:swagger-jaxrs2:$swaggerVersion")
 
             // Libraries for testing jersey controller actions
             testImplementation("org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-grizzly2:$jerseyVersion")

--- a/server/hazard-service/build.gradle
+++ b/server/hazard-service/build.gradle
@@ -7,8 +7,6 @@ dependencies {
     implementation "org.apache.commons:commons-csv:1.4"
     implementation "jgridshift:jgridshift:1.0"
     implementation "org.apache.commons:commons-math3:3.6.1"
-    implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.5'
     implementation group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.5.5'
-    implementation group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.4.9'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.0'
 }

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/CorsFilter.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/CorsFilter.java
@@ -10,10 +10,10 @@
 
 package edu.illinois.ncsa.incore.service.hazard;
 
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 
 public class CorsFilter implements ContainerResponseFilter {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
@@ -12,6 +12,8 @@ package edu.illinois.ncsa.incore.service.hazard.controllers;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.morphia.annotations.Property;
+import dev.morphia.annotations.experimental.Name;
 import edu.illinois.ncsa.incore.common.AllocationConstants;
 import edu.illinois.ncsa.incore.common.HazardConstants;
 import edu.illinois.ncsa.incore.common.auth.IAuthorizer;
@@ -42,17 +44,15 @@ import edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.GISUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.ServiceUtil;
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.*;
 import io.swagger.v3.oas.annotations.info.Contact;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -145,10 +145,15 @@ public class EarthquakeController {
         description = "Additionally, a GeoTiff (raster) is created by default and publish to data repository. " +
             "User can create both model earthquakes (with attenuation) and dataset-based earthquakes " +
             "with GeoTiff files uploaded.")
-    @Parameters({
-        @Parameter(name = "earthquake", description = "Earthquake json.", required = true, schema = @Schema(type = "string")),
-        @Parameter(name = "file", description = "Earthquake files.", required = true, schema = @Schema(type = "string"))
-    })
+
+    @RequestBody(description = "Earthquake json and files.", required = true,
+        content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+            schema = @Schema(type = "object",
+                properties = {@StringToClassMapItem(key = "earthquake", value = String.class),
+                              @StringToClassMapItem(key = "file", value = String.class)}
+            )
+    ))
+
     public Earthquake createEarthquake(
         @Parameter(hidden = true) @FormDataParam("earthquake") String eqJson,
         @Parameter(hidden = true) @FormDataParam("file") List<FormDataBodyPart> fileParts,
@@ -204,7 +209,6 @@ public class EarthquakeController {
                         datasetId = ServiceUtil.createRasterDataset(hazardFile, demandType + " hazard", this.username, this.userGroups,
                             description, HazardConstants.DETERMINISTIC_EARTHQUAKE_HAZARD_SCHEMA);
                     }
-
 
                     DeterministicHazardDataset rasterDataset = new DeterministicHazardDataset();
                     rasterDataset.setEqParameters(scenarioEarthquake.getEqParameters());

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
@@ -53,6 +53,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -93,6 +94,7 @@ import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.eqCompara
     )
 )
 
+@Tag(name = "earthquakes")
 
 @Path("earthquakes")
 @ApiResponses(value = {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/EarthquakeController.java
@@ -42,7 +42,21 @@ import edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.GISUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.ServiceUtil;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.log4j.Logger;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.glassfish.jersey.media.multipart.BodyPartEntity;
@@ -53,22 +67,16 @@ import org.json.JSONObject;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.opengis.coverage.grid.GridCoverage;
-
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.io.*;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.*;
 import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.eqComparator;
 
 
 // @SwaggerDefinition is common for all the service's controllers and can be put in any one of them
-@SwaggerDefinition(
+@OpenAPIDefinition(
     info = @Info(
         description = "IN-CORE Hazard Service For Earthquake, Tornado, Tsunami, Hurricane and Flood",
         version = "v0.6.3",
@@ -82,21 +90,13 @@ import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.eqCompara
             name = "Mozilla Public License 2.0 (MPL 2.0)",
             url = "https://www.mozilla.org/en-US/MPL/2.0/"
         )
-    ),
-    consumes = {"application/json"},
-    produces = {"application/json"},
-    schemes = {SwaggerDefinition.Scheme.HTTP}
-//    ,tags = {
-//        @Tag(name = "Private", description = "Tag used to denote operations as private")
-//    },
-    //externalDocs = @ExternalDocs(value = "FEMA  Hazard Manual", url = "https://www.fema.gov/earthquake")
+    )
 )
 
-@Api(value = "earthquakes", authorizations = {})
 
 @Path("earthquakes")
 @ApiResponses(value = {
-    @ApiResponse(code = 500, message = "Internal Server Error")
+    @ApiResponse(responseCode = "500", description = "Internal Server Error")
 })
 public class EarthquakeController {
     private static final Logger logger = Logger.getLogger(EarthquakeController.class);
@@ -131,8 +131,8 @@ public class EarthquakeController {
 
     @Inject
     public EarthquakeController(
-        @ApiParam(value = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
-        @ApiParam(value = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups) {
+        @Parameter(name = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
+        @Parameter(name = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups) {
         this.userGroups = userGroups;
         this.username = UserInfoUtils.getUsername(userInfo);
         this.groups = UserGroupUtils.getUserGroups(userGroups);
@@ -141,18 +141,18 @@ public class EarthquakeController {
     @POST
     @Consumes({MediaType.MULTIPART_FORM_DATA})
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Creates a new earthquake, the newly created earthquake is returned.",
-        notes = "Additionally, a GeoTiff (raster) is created by default and publish to data repository. " +
+    @Operation(summary = "Creates a new earthquake, the newly created earthquake is returned.",
+        description = "Additionally, a GeoTiff (raster) is created by default and publish to data repository. " +
             "User can create both model earthquakes (with attenuation) and dataset-based earthquakes " +
             "with GeoTiff files uploaded.")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "earthquake", value = "Earthquake json.", required = true, dataType = "string", paramType = "form"),
-        @ApiImplicitParam(name = "file", value = "Earthquake files.", required = true, dataType = "string", paramType = "form")
+    @Parameters({
+        @Parameter(name = "earthquake", description = "Earthquake json.", required = true, schema = @Schema(type = "string")),
+        @Parameter(name = "file", description = "Earthquake files.", required = true, schema = @Schema(type = "string"))
     })
     public Earthquake createEarthquake(
-        @ApiParam(hidden = true) @FormDataParam("earthquake") String eqJson,
-        @ApiParam(hidden = true) @FormDataParam("file") List<FormDataBodyPart> fileParts,
-        @ApiParam(value = "Use workflow service.", required = false) @QueryParam("useWorkflow") @DefaultValue("false") boolean useWorkflow) {
+        @Parameter(hidden = true) @FormDataParam("earthquake") String eqJson,
+        @Parameter(hidden = true) @FormDataParam("file") List<FormDataBodyPart> fileParts,
+        @Parameter(name = "Use workflow service.", required = false) @QueryParam("useWorkflow") @DefaultValue("false") boolean useWorkflow) {
         // TODO finish adding log statements
         // First, get the Earthquake object from the form
         // TODO what should be done if a user sends multiple earthquake objects?
@@ -294,13 +294,13 @@ public class EarthquakeController {
 
     @GET
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns all earthquakes.")
+    @Operation(summary = "Returns all earthquakes.")
     public List<Earthquake> getEarthquakes(
-        @ApiParam(value = "Name of the space.") @DefaultValue("") @QueryParam("space") String spaceName,
-        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
-        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
-        @ApiParam(value = "Skip the first n results.") @QueryParam("skip") int offset,
-        @ApiParam(value = "Limit number of results to return.") @DefaultValue("100") @QueryParam("limit") int limit
+        @Parameter(name = "Name of the space.") @DefaultValue("") @QueryParam("space") String spaceName,
+        @Parameter(name = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @Parameter(name = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
+        @Parameter(name = "Skip the first n results.") @QueryParam("skip") int offset,
+        @Parameter(name = "Limit number of results to return.") @DefaultValue("100") @QueryParam("limit") int limit
     ) {
         // import eq comparator
         Comparator<Earthquake> comparator = eqComparator(sortBy, order);
@@ -354,9 +354,9 @@ public class EarthquakeController {
     @GET
     @Path("{earthquake-id}")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns the earthquake with matching id.")
+    @Operation(summary = "Returns the earthquake with matching id.")
     public Earthquake getEarthquake(
-        @ApiParam(value = "Id of the earthquake.", required = true) @PathParam("earthquake-id") String earthquakeId) {
+        @Parameter(name = "Id of the earthquake.", required = true) @PathParam("earthquake-id") String earthquakeId) {
 
         Earthquake earthquake = repository.getEarthquakeById(earthquakeId);
         if (earthquake == null) {
@@ -382,19 +382,19 @@ public class EarthquakeController {
     @GET
     @Path("{earthquake-id}/raster")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns SeismicHazardResults for a given attenuation model-based earthquake id, demand type and unit, " +
-        "coordinates and grid spacing.", notes = " SeismicHazardResults contains the metadata about the raster " +
+    @Operation(summary = "Returns SeismicHazardResults for a given attenuation model-based earthquake id, demand type and unit, " +
+        "coordinates and grid spacing.", description = " SeismicHazardResults contains the metadata about the raster " +
         "data along with a list of HazardResults. Each HazardResult is a lat, long and hazard value.")
     public SeismicHazardResults getEarthquakeHazardForBox(
-        @ApiParam(value = "ID of the Earthquake.", required = true) @PathParam("earthquake-id") String earthquakeId,
-        @ApiParam(value = "Ground motion demand type. Ex: PGA, PGV, 0.2 SA, etc", required = true) @QueryParam("demandType") String demandType,
-        @ApiParam(value = "Ground motion demand unit. Ex: g, %g, cm/s, etc", required = true) @QueryParam("demandUnits") String demandUnits,
-        @ApiParam(value = "Bounding box of a raster. Min X.", required = true) @QueryParam("minX") double minX,
-        @ApiParam(value = "Bounding box of a raster. Min Y.", required = true) @QueryParam("minY") double minY,
-        @ApiParam(value = "Bounding box of a raster. Max X.", required = true) @QueryParam("maxX") double maxX,
-        @ApiParam(value = "Bounding box of a raster. max Y.", required = true) @QueryParam("maxY") double maxY,
-        @ApiParam(value = "Grid spacing.", required = true) @QueryParam("gridSpacing") double gridSpacing,
-        @ApiParam(value = "Amplify hazard.", required = false) @QueryParam("amplifyHazard") @DefaultValue("true") boolean amplifyHazard) {
+        @Parameter(name = "ID of the Earthquake.", required = true) @PathParam("earthquake-id") String earthquakeId,
+        @Parameter(name = "Ground motion demand type. Ex: PGA, PGV, 0.2 SA, etc", required = true) @QueryParam("demandType") String demandType,
+        @Parameter(name = "Ground motion demand unit. Ex: g, %g, cm/s, etc", required = true) @QueryParam("demandUnits") String demandUnits,
+        @Parameter(name = "Bounding box of a raster. Min X.", required = true) @QueryParam("minX") double minX,
+        @Parameter(name = "Bounding box of a raster. Min Y.", required = true) @QueryParam("minY") double minY,
+        @Parameter(name = "Bounding box of a raster. Max X.", required = true) @QueryParam("maxX") double maxX,
+        @Parameter(name = "Bounding box of a raster. max Y.", required = true) @QueryParam("maxY") double maxY,
+        @Parameter(name = "Grid spacing.", required = true) @QueryParam("gridSpacing") double gridSpacing,
+        @Parameter(name = "Amplify hazard.", required = false) @QueryParam("amplifyHazard") @DefaultValue("true") boolean amplifyHazard) {
 
         Earthquake eq = getEarthquake(earthquakeId);
         SeismicHazardResults results = null;
@@ -475,16 +475,16 @@ public class EarthquakeController {
     @Path("{earthquake-id}/values")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns earthquake values for a set of locations",
-        notes = "Outputs hazard values, demand types, unit and location.")
+    @Operation(summary = "Returns earthquake values for a set of locations",
+        description = "Outputs hazard values, demand types, unit and location.")
     public List<ValuesResponse> postEarthquakeValues(
-        @ApiParam(value = "Earthquake Id", required = true)
+        @Parameter(name = "Earthquake Id", required = true)
         @PathParam("earthquake-id") String earthquakeId,
-        @ApiParam(value = "Json of the points along with demand types and units",
+        @Parameter(name = "Json of the points along with demand types and units",
             required = true) @FormDataParam("points") String requestJsonStr,
-        @ApiParam(value = "Site class dataset from data service.", required = false)
+        @Parameter(name = "Site class dataset from data service.", required = false)
         @FormDataParam("siteClassId") @DefaultValue("") String siteClassId,
-        @ApiParam(value = "Amplify earthquake by soil type", required = false)
+        @Parameter(name = "Amplify earthquake by soil type", required = false)
         @FormDataParam("amplifyHazard") @DefaultValue("true") boolean amplifyHazard) {
 
         Earthquake eq = getEarthquake(earthquakeId);
@@ -595,15 +595,15 @@ public class EarthquakeController {
     @GET
     @Path("{earthquake-id}/values")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns hazard values for the given earthquake id.",
-        notes = "The results contain ground shaking parameter (PGA, SA, etc) for specific locations.")
+    @Operation(summary = "Returns hazard values for the given earthquake id.",
+        description = "The results contain ground shaking parameter (PGA, SA, etc) for specific locations.")
     @Deprecated
     public List<SeismicHazardResult> getEarthquakeHazardValues(
-        @ApiParam(value = "ID of the Earthquake.", required = true) @PathParam("earthquake-id") String earthquakeId,
-        @ApiParam(value = "Ground motion demand type. Ex: PGA, PGV, 0.2 SA, etc.", required = true) @QueryParam("demandType") String demandType,
-        @ApiParam(value = "Ground motion demand unit. Ex: g, %g, cm/s, etc.", required = true) @QueryParam("demandUnits") String demandUnits,
-        @ApiParam(value = "Amplify hazard by soil type.", required = false) @QueryParam("amplifyHazard") @DefaultValue("true") boolean amplifyHazard,
-        @ApiParam(value = "List of points provided as lat,long. Ex: '28.01,-83.85'.", required = true) @QueryParam("point") List<IncorePoint> points) {
+        @Parameter(name = "ID of the Earthquake.", required = true) @PathParam("earthquake-id") String earthquakeId,
+        @Parameter(name = "Ground motion demand type. Ex: PGA, PGV, 0.2 SA, etc.", required = true) @QueryParam("demandType") String demandType,
+        @Parameter(name = "Ground motion demand unit. Ex: g, %g, cm/s, etc.", required = true) @QueryParam("demandUnits") String demandUnits,
+        @Parameter(name = "Amplify hazard by soil type.", required = false) @QueryParam("amplifyHazard") @DefaultValue("true") boolean amplifyHazard,
+        @Parameter(name = "List of points provided as lat,long. Ex: '28.01,-83.85'.", required = true) @QueryParam("point") List<IncorePoint> points) {
 
         Earthquake eq = getEarthquake(earthquakeId);
 
@@ -658,10 +658,10 @@ public class EarthquakeController {
     @GET
     @Path("{earthquake-id}/aleatoryuncertainty")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns aleatory uncertainties for a model based earthquake")
+    @Operation(summary = "Returns aleatory uncertainties for a model based earthquake")
     public Map<String, Double> getEarthquakeAleatoricUncertainties(
-        @ApiParam(value = "ID of the Earthquake.", required = true) @PathParam("earthquake-id") String earthquakeId,
-        @ApiParam(value = "Demand Type. Ex: PGA.", required = true) @QueryParam("demandType") String demandType) {
+        @Parameter(name = "ID of the Earthquake.", required = true) @PathParam("earthquake-id") String earthquakeId,
+        @Parameter(name = "Demand Type. Ex: PGA.", required = true) @QueryParam("demandType") String demandType) {
         Earthquake eq = getEarthquake(earthquakeId);
         if (eq != null && eq instanceof EarthquakeModel) {
             EarthquakeModel earthquake = (EarthquakeModel) eq;
@@ -719,13 +719,13 @@ public class EarthquakeController {
     @GET
     @Path("{earthquake-id}/variance/{variance-type}")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns total and epistemic variance for a model based earthquake")
+    @Operation(summary = "Returns total and epistemic variance for a model based earthquake")
     public List<VarianceResult> getEarthquakeVariance(
-        @ApiParam(value = "ID of the Earthquake.", required = true) @PathParam("earthquake-id") String earthquakeId,
-        @ApiParam(value = "Type of Variance. epistemic or total", required = true) @PathParam("variance-type") String varianceType,
-        @ApiParam(value = "Demand Type. Ex: PGA.", required = true) @QueryParam("demandType") String demandType,
-        @ApiParam(value = "Demand unit. Ex: g.", required = true) @QueryParam("demandUnits") String demandUnits,
-        @ApiParam(value = "List of points provided as lat,long. Ex: '28.01,-83.85'.", required = true) @QueryParam("point") List<IncorePoint> points) {
+        @Parameter(name = "ID of the Earthquake.", required = true) @PathParam("earthquake-id") String earthquakeId,
+        @Parameter(name = "Type of Variance. epistemic or total", required = true) @PathParam("variance-type") String varianceType,
+        @Parameter(name = "Demand Type. Ex: PGA.", required = true) @QueryParam("demandType") String demandType,
+        @Parameter(name = "Demand unit. Ex: g.", required = true) @QueryParam("demandUnits") String demandUnits,
+        @Parameter(name = "List of points provided as lat,long. Ex: '28.01,-83.85'.", required = true) @QueryParam("point") List<IncorePoint> points) {
 
         Earthquake eq = getEarthquake(earthquakeId);
         List<VarianceResult> varianceResults = new ArrayList<>();
@@ -815,15 +815,15 @@ public class EarthquakeController {
     @Path("{earthquake-id}/liquefaction/values")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns liquefaction (PGD) values, probability of liquefaction, and probability of ground failure",
-        notes = "This needs a valid susceptibility dataset as a shapefile for a set of earthquake locations.")
+    @Operation(summary = "Returns liquefaction (PGD) values, probability of liquefaction, and probability of ground failure",
+        description = "This needs a valid susceptibility dataset as a shapefile for a set of earthquake locations.")
     public List<LiquefactionValuesResponse> postEarthquakeLiquefactionValues(
-        @ApiParam(value = "Earthquake Id", required = true)
+        @Parameter(name = "Earthquake Id", required = true)
         @PathParam("earthquake-id") String earthquakeId,
-        @ApiParam(value = "Json of the points along with demand types(pgd) and units",
+        @Parameter(name = "Json of the points along with demand types(pgd) and units",
             required = true) @FormDataParam("points") String requestJsonStr,
-        @ApiParam(value = "Geology dataset from data service.", required = true)
-        @FormDataParam("geologyDataset") String geologyId, @ApiParam(value = "Site class dataset from data service.", required = false)
+        @Parameter(name = "Geology dataset from data service.", required = true)
+        @FormDataParam("geologyDataset") String geologyId, @Parameter(name = "Site class dataset from data service.", required = false)
         @FormDataParam("siteClassId") @DefaultValue("") String siteClassId) {
         Earthquake eq = getEarthquake(earthquakeId);
 
@@ -901,14 +901,14 @@ public class EarthquakeController {
     @GET
     @Path("{earthquake-id}/liquefaction/values")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns liquefaction (PGD) values, probability of liquefaction, and probability of ground failure.",
-        notes = "This needs a valid susceptibility dataset as a shapefile for the earthquake location.")
+    @Operation(summary = "Returns liquefaction (PGD) values, probability of liquefaction, and probability of ground failure.",
+        description = "This needs a valid susceptibility dataset as a shapefile for the earthquake location.")
     @Deprecated
     public List<LiquefactionHazardResult> getEarthquakeLiquefaction(
-        @ApiParam(value = "ID of the Earthquake.", required = true) @PathParam("earthquake-id") String earthquakeId,
-        @ApiParam(value = "Geology dataset from data service.", required = true) @QueryParam("geologyDataset") String geologyId,
-        @ApiParam(value = "Liquefaction demand unit. Ex: in, cm, etc", required = true) @QueryParam("demandUnits") String demandUnits,
-        @ApiParam(value = "List of points provided as lat,long. Ex: '28.01,-83.85'", required = true) @QueryParam("point") List<IncorePoint> points) {
+        @Parameter(name = "ID of the Earthquake.", required = true) @PathParam("earthquake-id") String earthquakeId,
+        @Parameter(name = "Geology dataset from data service.", required = true) @QueryParam("geologyDataset") String geologyId,
+        @Parameter(name = "Liquefaction demand unit. Ex: in, cm, etc", required = true) @QueryParam("demandUnits") String demandUnits,
+        @Parameter(name = "List of points provided as lat,long. Ex: '28.01,-83.85'", required = true) @QueryParam("point") List<IncorePoint> points) {
         Earthquake eq = getEarthquake(earthquakeId);
         // TODO add logging/error for earthquake dataset that it can't be used
         if (eq != null && eq instanceof EarthquakeModel) {
@@ -942,17 +942,17 @@ public class EarthquakeController {
     @GET
     @Path("/soil/amplification")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns earthquake site hazard amplification.", notes = " This returns the amplified " +
+    @Operation(summary = "Returns earthquake site hazard amplification.", description = " This returns the amplified " +
         "hazard given a methodology (e.g. NEHRP), soil map dataset id (optional), latitude, longitude, ground shaking " +
         "parameter (PGA, Sa, etc), hazard value, and default site class to use.")
     public Response getEarthquakeSiteAmplification(
-        @ApiParam(value = "Method to get hazard amplification.", required = true) @QueryParam("method") String method,
-        @ApiParam(value = "ID of site class dataset from data service.", required = true) @QueryParam("datasetId") @DefaultValue("") String datasetId,
-        @ApiParam(value = "Latitude coordinate of the site.", required = true) @QueryParam("siteLat") double siteLat,
-        @ApiParam(value = "Longitude coordinate of the site.", required = true) @QueryParam("siteLong") double siteLong,
-        @ApiParam(value = "Ground motion demand type. Ex: PGA, PGV, 0.2 SA, etc.", required = true) @QueryParam("demandType") String demandType,
-        @ApiParam(value = "Hazard value.", required = true) @QueryParam("hazard") double hazard,
-        @ApiParam(value = "Default site classification. Expected  A, B, C, D, E or F.") @QueryParam("defaultSiteClass") String defaultSiteClass) {
+        @Parameter(name = "Method to get hazard amplification.", required = true) @QueryParam("method") String method,
+        @Parameter(name = "ID of site class dataset from data service.", required = true) @QueryParam("datasetId") @DefaultValue("") String datasetId,
+        @Parameter(name = "Latitude coordinate of the site.", required = true) @QueryParam("siteLat") double siteLat,
+        @Parameter(name = "Longitude coordinate of the site.", required = true) @QueryParam("siteLong") double siteLong,
+        @Parameter(name = "Ground motion demand type. Ex: PGA, PGV, 0.2 SA, etc.", required = true) @QueryParam("demandType") String demandType,
+        @Parameter(name = "Hazard value.", required = true) @QueryParam("hazard") double hazard,
+        @Parameter(name = "Default site classification. Expected  A, B, C, D, E or F.") @QueryParam("defaultSiteClass") String defaultSiteClass) {
 
         int localSiteClass = HazardUtil.getSiteClassAsInt(defaultSiteClass);
         if (localSiteClass == -1) {
@@ -989,10 +989,10 @@ public class EarthquakeController {
     @GET
     @Path("/slope/amplification")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(hidden = true, value = "Returns earthquake slope amplification.")
+    @Operation(hidden = true, summary = "Returns earthquake slope amplification.")
     public Response getEarthquakeSlopeAmplification(
-        @ApiParam(hidden = true, value = "Latitude coordinate of the site.") @QueryParam("siteLat") double siteLat,
-        @ApiParam(hidden = true, value = "Longitude coordinate of the site.") @QueryParam("siteLong") double siteLong) {
+        @Parameter(hidden = true, name = "Latitude coordinate of the site.") @QueryParam("siteLat") double siteLat,
+        @Parameter(hidden = true, name = "Longitude coordinate of the site.") @QueryParam("siteLong") double siteLong) {
 
         return Response.ok("Topographic amplification not yet implemented").build();
     }
@@ -1000,7 +1000,7 @@ public class EarthquakeController {
     @GET
     @Path("models")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(hidden = true, value = "Returns available attenuation models.", notes = "This returns the available " +
+    @Operation(hidden = true, summary = "Returns available attenuation models.", description = "This returns the available " +
         "attenuation models.")
     public Set<String> getSupportedEarthquakeModels() {
         return attenuationProvider.getAttenuations().keySet();
@@ -1009,16 +1009,16 @@ public class EarthquakeController {
     @GET
     @Path("/search")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Search for a text in all earthquakes", notes = "Gets all earthquakes that contain a specific text")
+    @Operation(summary = "Search for a text in all earthquakes", description = "Gets all earthquakes that contain a specific text")
     @ApiResponses(value = {
-        @ApiResponse(code = 404, message = "No earthquakes found with the searched text")
+        @ApiResponse(responseCode = "404", description = "No earthquakes found with the searched text")
     })
     public List<Earthquake> findEarthquakes(
-        @ApiParam(value = "Text to search by", example = "building") @QueryParam("text") String text,
-        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
-        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
-        @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
-        @ApiParam(value = "Limit number of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+        @Parameter(name = "Text to search by", example = "building") @QueryParam("text") String text,
+        @Parameter(name = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @Parameter(name = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
+        @Parameter(name = "Skip the first n results") @QueryParam("skip") int offset,
+        @Parameter(name = "Limit number of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
 
         // import eq comparator
         Comparator<Earthquake> comparator = eqComparator(sortBy, order);
@@ -1051,8 +1051,8 @@ public class EarthquakeController {
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{earthquake-id}")
-    @ApiOperation(value = "Deletes an earthquake", notes = "Also deletes attached dataset and related files")
-    public Earthquake deleteEarthquake(@ApiParam(value = "Earthquake Id", required = true) @PathParam("earthquake-id") String earthquakeId) {
+    @Operation(summary = "Deletes an earthquake", description = "Also deletes attached dataset and related files")
+    public Earthquake deleteEarthquake(@Parameter(name = "Earthquake Id", required = true) @PathParam("earthquake-id") String earthquakeId) {
         Earthquake eq = getEarthquake(earthquakeId);
 
         if (authorizer.canUserDeleteMember(this.username, earthquakeId, spaceRepository.getAllSpaces(), this.groups)) {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/FloodController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/FloodController.java
@@ -36,14 +36,10 @@ import edu.illinois.ncsa.incore.service.hazard.models.flood.types.FloodHazardRes
 import edu.illinois.ncsa.incore.service.hazard.models.flood.utils.FloodCalc;
 import edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.ServiceUtil;
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.info.Contact;
-import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.inject.Inject;
@@ -187,14 +183,15 @@ public class FloodController {
     @Operation(summary = "Creates a new flood, the newly created flood is returned.",
         description = "Additionally, a GeoTiff (raster) is created by default and publish to data repository. " +
             "User can create dataset-based floods only.")
-//    @ApiImplicitParams({
-//        @ApiImplicitParam(name = "flood", value = "Flood json.", required = true, dataType = "string", paramType = "form"),
-//        @ApiImplicitParam(name = "file", value = "Flood files.", required = true, dataType = "string", paramType = "form")
-//    })
-    @Parameters({
-        @Parameter(name = "flood", description = "Flood json.", required = true, schema = @Schema(type = "string")),
-        @Parameter(name = "file", description = "Flood files.", required = true, schema = @Schema(type = "string"))
-    })
+
+    @RequestBody(description = "Flood json and files.", required = true,
+        content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+            schema = @Schema(type = "object",
+                properties = {@StringToClassMapItem(key = "flood", value = String.class),
+                    @StringToClassMapItem(key = "file", value = String.class)}
+            )
+        )
+    )
     public Flood createFlood(
         @Parameter(hidden = true) @FormDataParam("flood") String floodJson,
         @Parameter(hidden = true) @FormDataParam("file") List<FormDataBodyPart> fileParts) {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/FloodController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/FloodController.java
@@ -36,7 +36,20 @@ import edu.illinois.ncsa.incore.service.hazard.models.flood.types.FloodHazardRes
 import edu.illinois.ncsa.incore.service.hazard.models.flood.utils.FloodCalc;
 import edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.ServiceUtil;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.log4j.Logger;
 import org.glassfish.jersey.media.multipart.BodyPartEntity;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
@@ -44,10 +57,6 @@ import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -61,11 +70,10 @@ import java.util.stream.Collectors;
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.*;
 import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.floodComparator;
 
-@Api(value = "floods", authorizations = {})
 
 @Path("floods")
 @ApiResponses(value = {
-    @ApiResponse(code = 500, message = "Internal Server Error")
+    @ApiResponse(responseCode = "500", description = "Internal Server Error")
 })
 public class FloodController {
     private static final Logger log = Logger.getLogger(FloodController.class);
@@ -93,8 +101,8 @@ public class FloodController {
 
     @Inject
     public FloodController(
-        @ApiParam(value = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
-        @ApiParam(value = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups
+        @Parameter(name = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
+        @Parameter(name = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups
     ) {
         this.userGroups = userGroups;
         this.username = UserInfoUtils.getUsername(userInfo);
@@ -103,13 +111,13 @@ public class FloodController {
 
     @GET
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns all floods.")
+    @Operation(summary = "Returns all floods.")
     public List<Flood> getFloods(
-        @ApiParam(value = "Name of space.") @DefaultValue("") @QueryParam("space") String spaceName,
-        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
-        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
-        @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
-        @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+        @Parameter(name = "Name of space.") @DefaultValue("") @QueryParam("space") String spaceName,
+        @Parameter(name = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @Parameter(name = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
+        @Parameter(name = "Skip the first n results") @QueryParam("skip") int offset,
+        @Parameter(name = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
 
         // import flood comparator
         Comparator<Flood> comparator = floodComparator(sortBy, order);
@@ -155,9 +163,9 @@ public class FloodController {
     @GET
     @Path("{flood-id}")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns the flood with matching id.")
+    @Operation(summary = "Returns the flood with matching id.")
     public Flood getFloodById(
-        @ApiParam(value = "Flood dataset guid from data service.", required = true) @PathParam("flood-id") String floodId) {
+        @Parameter(name = "Flood dataset guid from data service.", required = true) @PathParam("flood-id") String floodId) {
 
         Flood flood = repository.getFloodById(floodId);
         if (flood == null) {
@@ -176,16 +184,20 @@ public class FloodController {
     @POST
     @Consumes({MediaType.MULTIPART_FORM_DATA})
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Creates a new flood, the newly created flood is returned.",
-        notes = "Additionally, a GeoTiff (raster) is created by default and publish to data repository. " +
+    @Operation(summary = "Creates a new flood, the newly created flood is returned.",
+        description = "Additionally, a GeoTiff (raster) is created by default and publish to data repository. " +
             "User can create dataset-based floods only.")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "flood", value = "Flood json.", required = true, dataType = "string", paramType = "form"),
-        @ApiImplicitParam(name = "file", value = "Flood files.", required = true, dataType = "string", paramType = "form")
+//    @ApiImplicitParams({
+//        @ApiImplicitParam(name = "flood", value = "Flood json.", required = true, dataType = "string", paramType = "form"),
+//        @ApiImplicitParam(name = "file", value = "Flood files.", required = true, dataType = "string", paramType = "form")
+//    })
+    @Parameters({
+        @Parameter(name = "flood", description = "Flood json.", required = true, schema = @Schema(type = "string")),
+        @Parameter(name = "file", description = "Flood files.", required = true, schema = @Schema(type = "string"))
     })
     public Flood createFlood(
-        @ApiParam(hidden = true) @FormDataParam("flood") String floodJson,
-        @ApiParam(hidden = true) @FormDataParam("file") List<FormDataBodyPart> fileParts) {
+        @Parameter(hidden = true) @FormDataParam("flood") String floodJson,
+        @Parameter(hidden = true) @FormDataParam("file") List<FormDataBodyPart> fileParts) {
 
         // check if the user's number of the hazard is within the allocation
         if (!AllocationUtils.canCreateAnyDataset(allocationsRepository, quotaRepository, this.username, "hazards")) {
@@ -279,12 +291,12 @@ public class FloodController {
     @Path("{flood-id}/values")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns flood values for a set of locations",
-        notes = "Outputs hazard values, demand types, unit and location.")
+    @Operation(summary = "Returns flood values for a set of locations",
+        description = "Outputs hazard values, demand types, unit and location.")
     public List<ValuesResponse> postFloodValues(
-        @ApiParam(value = "Glood Id", required = true)
+        @Parameter(name = "Glood Id", required = true)
         @PathParam("flood-id") String floodId,
-        @ApiParam(value = "Json of the points along with demand types and units",
+        @Parameter(name = "Json of the points along with demand types and units",
             required = true) @FormDataParam("points") String requestJsonStr) {
         Flood flood = getFloodById(floodId);
 
@@ -374,8 +386,8 @@ public class FloodController {
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{flood-id}")
-    @ApiOperation(value = "Deletes a flood", notes = "Also deletes attached datasets and related files")
-    public Flood deleteFlood(@ApiParam(value = "Flood Id", required = true) @PathParam("flood-id") String floodId) {
+    @Operation(summary = "Deletes a flood", description = "Also deletes attached datasets and related files")
+    public Flood deleteFlood(@Parameter(name = "Flood Id", required = true) @PathParam("flood-id") String floodId) {
         Flood flood = getFloodById(floodId);
 
         if (authorizer.canUserDeleteMember(this.username, floodId, spaceRepository.getAllSpaces(), this.groups)) {
@@ -416,16 +428,16 @@ public class FloodController {
     @GET
     @Path("/search")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Search for a text in all floods", notes = "Gets all floods that contain a specific text")
+    @Operation(summary = "Search for a text in all floods", description = "Gets all floods that contain a specific text")
     @ApiResponses(value = {
-        @ApiResponse(code = 404, message = "No floods found with the searched text")
+        @ApiResponse(responseCode = "404", description = "No floods found with the searched text")
     })
     public List<Flood> findFloods(
-        @ApiParam(value = "Text to search by", example = "building") @QueryParam("text") String text,
-        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
-        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
-        @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
-        @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+        @Parameter(name = "Text to search by", example = "building") @QueryParam("text") String text,
+        @Parameter(name = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @Parameter(name = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
+        @Parameter(name = "Skip the first n results") @QueryParam("skip") int offset,
+        @Parameter(name = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
 
         // import flood comparator
         Comparator<Flood> comparator = floodComparator(sortBy, order);

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/FloodController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/FloodController.java
@@ -42,6 +42,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -66,6 +67,7 @@ import java.util.stream.Collectors;
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.*;
 import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.floodComparator;
 
+@Tag(name = "floods")
 
 @Path("floods")
 @ApiResponses(value = {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/HurricaneController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/HurricaneController.java
@@ -28,14 +28,10 @@ import edu.illinois.ncsa.incore.service.hazard.models.hurricane.types.HurricaneH
 import edu.illinois.ncsa.incore.service.hazard.models.hurricane.utils.HurricaneCalc;
 import edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.ServiceUtil;
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.info.Contact;
-import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.inject.Inject;
@@ -181,14 +177,15 @@ public class HurricaneController {
     @Operation(summary = "Creates a new hurricane, the newly created hurricane is returned.",
         description = "Additionally, a GeoTiff (raster) is created by default and publish to data repository. " +
             "User can create dataset-based hurricanes only.")
-//    @ApiImplicitParams({
-//        @ApiImplicitParam(name = "hurricane", value = "Hurricane json.", required = true, dataType = "string", paramType = "form"),
-//        @ApiImplicitParam(name = "file", value = "Hurricane files.", required = true, dataType = "string", paramType = "form")
-//    })
-    @Parameters({
-        @Parameter(name = "hurricane", description = "Hurricane json.", required = true, schema = @Schema(type = "string")),
-        @Parameter(name = "file", description = "Hurricane files.", required = true, schema = @Schema(type = "string"))
-    })
+
+    @RequestBody(description = "Hurricane json and files.", required = true,
+        content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+            schema = @Schema(type = "object",
+                properties = {@StringToClassMapItem(key = "hurricane", value = String.class),
+                    @StringToClassMapItem(key = "file", value = String.class)}
+            )
+        )
+    )
     public Hurricane createHurricane(
         @Parameter(hidden = true) @FormDataParam("hurricane") String hurricaneJson,
         @Parameter(hidden = true) @FormDataParam("file") List<FormDataBodyPart> fileParts) {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/HurricaneController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/HurricaneController.java
@@ -34,6 +34,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -58,6 +59,7 @@ import java.util.stream.Collectors;
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.*;
 import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.hurricaneComparator;
 
+@Tag(name = "hurricanes")
 
 @Path("hurricanes")
 @ApiResponses(value = {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/HurricaneWindfieldsController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/HurricaneWindfieldsController.java
@@ -39,17 +39,24 @@ import edu.illinois.ncsa.incore.service.hazard.models.hurricaneWindfields.utils.
 import edu.illinois.ncsa.incore.service.hazard.models.hurricaneWindfields.utils.HurricaneWindfieldsUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.ServiceUtil;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.log4j.Logger;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.opengis.geometry.MismatchedDimensionException;
 
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -60,11 +67,9 @@ import java.util.stream.Collectors;
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.INVALID_DEMAND;
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.INVALID_UNIT;
 
-@Api(value = "hurricaneWindfields", authorizations = {})
-
 @Path("hurricaneWindfields")
 @ApiResponses(value = {
-    @ApiResponse(code = 500, message = "Internal Server Error")
+    @ApiResponse(responseCode = "500", description = "Internal Server Error")
 })
 public class HurricaneWindfieldsController {
     private static final Logger log = Logger.getLogger(HurricaneWindfieldsController.class);
@@ -92,8 +97,8 @@ public class HurricaneWindfieldsController {
 
     @Inject
     public HurricaneWindfieldsController(
-        @ApiParam(value = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
-        @ApiParam(value = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups
+        @Parameter(name = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
+        @Parameter(name = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups
     ) {
         this.userGroups = userGroups;
         this.username = UserInfoUtils.getUsername(userInfo);
@@ -102,13 +107,13 @@ public class HurricaneWindfieldsController {
 
     @GET
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns all hurricanes.")
+    @Operation(summary = "Returns all hurricanes.")
     public List<HurricaneWindfields> getHurricaneWindfields(
-        @ApiParam(value = "Hurricane coast. Ex: 'gulf, florida or east'.", required = true) @QueryParam("coast") String coast,
-        @ApiParam(value = "Hurricane category. Ex: between 1 and 5.", required = true) @QueryParam("category") int category,
-        @ApiParam(value = "Name of space.") @DefaultValue("") @QueryParam("space") String spaceName,
-        @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
-        @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+        @Parameter(name = "Hurricane coast. Ex: 'gulf, florida or east'.", required = true) @QueryParam("coast") String coast,
+        @Parameter(name = "Hurricane category. Ex: between 1 and 5.", required = true) @QueryParam("category") int category,
+        @Parameter(name = "Name of space.") @DefaultValue("") @QueryParam("space") String spaceName,
+        @Parameter(name = "Skip the first n results") @QueryParam("skip") int offset,
+        @Parameter(name = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
 
         List<HurricaneWindfields> hurricaneWindfields = repository.getHurricaneWindfields();
         if (!spaceName.equals("")) {
@@ -159,8 +164,8 @@ public class HurricaneWindfieldsController {
     @POST
     @Consumes({MediaType.APPLICATION_JSON})
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Creates a new hurricane, simulation of hurricane windfields is returned.",
-        notes = "One dataset for each time frame of the simulation is returned representing the hurricane " +
+    @Operation(summary = "Creates a new hurricane, simulation of hurricane windfields is returned.",
+        description = "One dataset for each time frame of the simulation is returned representing the hurricane " +
             "windfield's raster. Each cell represents the windspeed at 10m elevation and 3-sec wind gust by default")
     public HurricaneWindfields createHurricaneWindfields(
         HurricaneWindfields inputHurricane) {
@@ -256,9 +261,9 @@ public class HurricaneWindfieldsController {
     @GET
     @Path("{hurricaneId}")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns the hurricane with matching id.")
+    @Operation(summary = "Returns the hurricane with matching id.")
     public HurricaneWindfields getHurricaneWindfieldsById(
-        @ApiParam(value = "Hurricane dataset guid from data service.", required = true) @PathParam("hurricaneId") String hurricaneId) {
+        @Parameter(name = "Hurricane dataset guid from data service.", required = true) @PathParam("hurricaneId") String hurricaneId) {
 
         HurricaneWindfields hurricane = repository.getHurricaneWindfieldsById(hurricaneId);
         if (hurricane == null) {
@@ -278,16 +283,16 @@ public class HurricaneWindfieldsController {
     @Path("{hurricaneId}/values")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns hurricane wind field values for a set of locations",
-        notes = "Outputs hazard values, demand types, unit and location.")
+    @Operation(summary = "Returns hurricane wind field values for a set of locations",
+        description = "Outputs hazard values, demand types, unit and location.")
     public List<ValuesResponse> postHurricaneWindFieldValues(
-        @ApiParam(value = "hurricane wind field Id", required = true)
+        @Parameter(name = "hurricane wind field Id", required = true)
         @PathParam("hurricaneId") String hurricaneId,
-        @ApiParam(value = "Json of the points along with demand types and units",
+        @Parameter(name = "Json of the points along with demand types and units",
             required = true) @FormDataParam("points") String requestJsonStr,
-        @ApiParam(value = "Elevation in meters at which wind speed has to be calculated.") @FormDataParam("elevation") @DefaultValue("10" +
+        @Parameter(name = "Elevation in meters at which wind speed has to be calculated.") @FormDataParam("elevation") @DefaultValue("10" +
             ".0") double elevation,
-        @ApiParam(value = "Terrain exposure or roughness length. Acceptable range is 0.003 to 2.5 ") @FormDataParam("roughness") @DefaultValue("0.03") double roughness) {
+        @Parameter(name = "Terrain exposure or roughness length. Acceptable range is 0.003 to 2.5 ") @FormDataParam("roughness") @DefaultValue("0.03") double roughness) {
 
         HurricaneWindfields hurricane = getHurricaneWindfieldsById(hurricaneId);
 
@@ -376,8 +381,8 @@ public class HurricaneWindfieldsController {
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{hurricaneId}")
-    @ApiOperation(value = "Deletes a Hurricane Windfield", notes = "Also deletes attached datasets and related files")
-    public HurricaneWindfields deleteHurricaneWindfields(@ApiParam(value = "Hurricane Windfield Id", required = true) @PathParam(
+    @Operation(summary = "Deletes a Hurricane Windfield", description = "Also deletes attached datasets and related files")
+    public HurricaneWindfields deleteHurricaneWindfields(@Parameter(name = "Hurricane Windfield Id", required = true) @PathParam(
         "hurricaneId") String hurricaneId) {
         HurricaneWindfields hurricane = getHurricaneWindfieldsById(hurricaneId);
 
@@ -413,18 +418,18 @@ public class HurricaneWindfieldsController {
     @GET
     @Path("json/{coast}")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(hidden = true, value = "Simulates a hurricane by returning the result as json.",
-        notes = "It is implemented to match MATLAB output and need not be exposed to external users")
+    @Operation(hidden = true, summary = "Simulates a hurricane by returning the result as json.",
+        description = "It is implemented to match MATLAB output and need not be exposed to external users")
     public HurricaneSimulationEnsemble getHurricaneJsonByCategory(
-        @ApiParam(value = "Hurricane coast. Ex: 'gulf, florida or east'.", required = true) @PathParam("coast") String coast,
-        @ApiParam(value = "Hurricane category. Ex: between 1 and 5.", required = true) @QueryParam("category") int category,
-        @ApiParam(value = "Huricane landfall direction angle. Ex: 30.5.", required = true) @QueryParam("TransD") double transD,
-        @ApiParam(value = "Huricane landfall location. Ex: '28.09,-80.62'.", required = true) @QueryParam("LandfallLoc") IncorePoint landfallLoc,
-        @ApiParam(value = "Hurricane demand type. Ex. '3s', '60s'.", required = true) @QueryParam("demandType") String demandType,
-        @ApiParam(value = "Hurricane demand unit.", required = true) @QueryParam("demandUnits") String demandUnits,
-        @ApiParam(value = "Resolution. Ex: 6.", required = true) @QueryParam("resolution") @DefaultValue("6") int resolution,
-        @ApiParam(value = "Number of grid points. Ex: 80.", required = true) @QueryParam("gridPoints") @DefaultValue("80") int gridPoints,
-        @ApiParam(value = "Reduction type. Ex: 'circular'.", required = true) @QueryParam("reductionType") @DefaultValue("circular") String rfMethod) {
+        @Parameter(name = "Hurricane coast. Ex: 'gulf, florida or east'.", required = true) @PathParam("coast") String coast,
+        @Parameter(name = "Hurricane category. Ex: between 1 and 5.", required = true) @QueryParam("category") int category,
+        @Parameter(name = "Huricane landfall direction angle. Ex: 30.5.", required = true) @QueryParam("TransD") double transD,
+        @Parameter(name = "Huricane landfall location. Ex: '28.09,-80.62'.", required = true) @QueryParam("LandfallLoc") IncorePoint landfallLoc,
+        @Parameter(name = "Hurricane demand type. Ex. '3s', '60s'.", required = true) @QueryParam("demandType") String demandType,
+        @Parameter(name = "Hurricane demand unit.", required = true) @QueryParam("demandUnits") String demandUnits,
+        @Parameter(name = "Resolution. Ex: 6.", required = true) @QueryParam("resolution") @DefaultValue("6") int resolution,
+        @Parameter(name = "Number of grid points. Ex: 80.", required = true) @QueryParam("gridPoints") @DefaultValue("80") int gridPoints,
+        @Parameter(name = "Reduction type. Ex: 'circular'.", required = true) @QueryParam("reductionType") @DefaultValue("circular") String rfMethod) {
 
         //TODO: Handle both cases Sandy/sandy. Standardize to lower case?
         if (coast == null || category <= 0 || category > 5) {
@@ -444,14 +449,14 @@ public class HurricaneWindfieldsController {
     @GET
     @Path("/search")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Search for a text in all hurricanes", notes = "Gets all hurricanes that contain a specific text")
+    @Operation(summary = "Search for a text in all hurricanes", description = "Gets all hurricanes that contain a specific text")
     @ApiResponses(value = {
-        @ApiResponse(code = 404, message = "No hurricanes found with the searched text")
+        @ApiResponse(responseCode = "404", description = "No hurricanes found with the searched text")
     })
     public List<HurricaneWindfields> findHurricaneWindfields(
-        @ApiParam(value = "Text to search by", example = "building") @QueryParam("text") String text,
-        @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
-        @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+        @Parameter(name = "Text to search by", example = "building") @QueryParam("text") String text,
+        @Parameter(name = "Skip the first n results") @QueryParam("skip") int offset,
+        @Parameter(name = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
 
         List<HurricaneWindfields> hurricanes;
         HurricaneWindfields hurricane = repository.getHurricaneWindfieldsById(text);

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/HurricaneWindfieldsController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/HurricaneWindfieldsController.java
@@ -47,6 +47,7 @@ import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.info.License;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -66,6 +67,8 @@ import java.util.stream.Collectors;
 
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.INVALID_DEMAND;
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.INVALID_UNIT;
+
+@Tag(name = "hurricaneWindfields")
 
 @Path("hurricaneWindfields")
 @ApiResponses(value = {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/StatusController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/StatusController.java
@@ -6,6 +6,7 @@ import edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -14,6 +15,8 @@ import org.apache.log4j.Logger;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
+
+@Tag(name = "status")
 
 @Path("status")
 @ApiResponses(value = {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/StatusController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/StatusController.java
@@ -3,28 +3,21 @@ package edu.illinois.ncsa.incore.service.hazard.controllers;
 import edu.illinois.ncsa.incore.common.exceptions.IncoreHTTPException;
 import edu.illinois.ncsa.incore.service.hazard.dao.*;
 import edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.log4j.Logger;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
-@Api(value = "status", authorizations = {})
-
 @Path("status")
 @ApiResponses(value = {
-    @ApiResponse(code = 500, message = "Internal Server Error")
+    @ApiResponse(responseCode = "500", description = "Internal Server Error")
 })
 public class StatusController {
     private static final Logger logger = Logger.getLogger(StatusController.class);
@@ -49,8 +42,8 @@ public class StatusController {
 
     @GET
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Gives the status of the service.",
-        notes = "This will provide the status of the service as a JSON.")
+    @Operation(summary = "Gives the status of the service.",
+        description = "This will provide the status of the service as a JSON.")
     public String getStatus() {
         String statusJson = "{\"status\": \"responding\"}";
         return statusJson;
@@ -59,7 +52,7 @@ public class StatusController {
     @GET
     @Path("usage")
     @Produces(MediaType.APPLICATION_JSON)
-    @ApiOperation(value = "Gives the count for each hazard.", notes = "")
+    @Operation(summary = "Gives the count for each hazard.", description = "")
     public String getUserStatusHazards(@HeaderParam("x-auth-userinfo") String userInfo) {
         int numEarthquakes = 0;
         int numFloods = 0;

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TornadoController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TornadoController.java
@@ -34,14 +34,10 @@ import edu.illinois.ncsa.incore.service.hazard.models.tornado.utils.TornadoCalc;
 import edu.illinois.ncsa.incore.service.hazard.models.tornado.utils.TornadoUtils;
 import edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.ServiceUtil;
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.info.Contact;
-import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.inject.Inject;
@@ -71,7 +67,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.*;
-import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.hurricaneComparator;
 import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.tornadoComparator;
 
 
@@ -173,14 +168,15 @@ public class TornadoController {
     @Operation(summary = "Creates a new tornado, the newly created tornado is returned.",
         description = "Additionally, a GeoTiff (raster) is created by default and publish to data repository. " +
             "User can create both model tornadoes and dataset-based tornadoes with GeoTiff files uploaded.")
-//    @ApiImplicitParams({
-//        @ApiImplicitParam(name = "tornado", value = "Tornado json.", required = true, dataType = "string", paramType = "form"),
-//        @ApiImplicitParam(name = "file", value = "Tornado files.", required = true, dataType = "string", paramType = "form")
-//    })
-    @Parameters({
-        @Parameter(name = "tornado", description = "Tornado json.", required = true, schema = @Schema(type = "string")),
-        @Parameter(name = "file", description = "Tornado files.", required = true, schema = @Schema(type = "string"))
-    })
+
+    @RequestBody(description = "Tornado json and files.", required = true,
+        content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+            schema = @Schema(type = "object",
+                properties = {@StringToClassMapItem(key = "tornado", value = String.class),
+                    @StringToClassMapItem(key = "file", value = String.class)}
+            )
+        )
+    )
     public Tornado createTornado(
         @Parameter(hidden = true) @FormDataParam("tornado") String tornadoJson,
         @Parameter(hidden = true) @FormDataParam("file") List<FormDataBodyPart> fileParts) {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TornadoController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TornadoController.java
@@ -40,6 +40,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -69,6 +70,7 @@ import java.util.stream.Collectors;
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.*;
 import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.tornadoComparator;
 
+@Tag(name = "tornadoes")
 
 @Path("tornadoes")
 @ApiResponses(value = {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TornadoController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TornadoController.java
@@ -34,7 +34,20 @@ import edu.illinois.ncsa.incore.service.hazard.models.tornado.utils.TornadoCalc;
 import edu.illinois.ncsa.incore.service.hazard.models.tornado.utils.TornadoUtils;
 import edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.ServiceUtil;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
 import org.apache.log4j.Logger;
 import org.geotools.data.simple.SimpleFeatureCollection;
@@ -47,10 +60,6 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -65,11 +74,10 @@ import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil
 import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.hurricaneComparator;
 import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.tornadoComparator;
 
-@Api(value = "tornadoes", authorizations = {})
 
 @Path("tornadoes")
 @ApiResponses(value = {
-    @ApiResponse(code = 500, message = "Internal Server Error.")
+    @ApiResponse(responseCode = "500", description = "Internal Server Error")
 })
 public class TornadoController {
     private static final Logger logger = Logger.getLogger(TornadoController.class);
@@ -99,8 +107,8 @@ public class TornadoController {
 
     @Inject
     public TornadoController(
-        @ApiParam(value = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
-        @ApiParam(value = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups
+        @Parameter(name = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
+        @Parameter(name = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups
     ) {
         this.userGroups = userGroups;
         this.username = UserInfoUtils.getUsername(userInfo);
@@ -109,13 +117,13 @@ public class TornadoController {
 
     @GET
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns all tornadoes.")
+    @Operation(summary = "Returns all tornadoes.")
     public List<Tornado> getTornadoes(
-        @ApiParam(value = "Name of space.") @DefaultValue("") @QueryParam("space") String spaceName,
-        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
-        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
-        @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
-        @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+        @Parameter(name = "Name of space.") @DefaultValue("") @QueryParam("space") String spaceName,
+        @Parameter(name = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @Parameter(name = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
+        @Parameter(name = "Skip the first n results") @QueryParam("skip") int offset,
+        @Parameter(name = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
 
         // import tornado comparator
         Comparator<Tornado> comparator = tornadoComparator(sortBy, order);
@@ -162,16 +170,20 @@ public class TornadoController {
     @POST
     @Consumes({MediaType.MULTIPART_FORM_DATA})
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Creates a new tornado, the newly created tornado is returned.",
-        notes = "Additionally, a GeoTiff (raster) is created by default and publish to data repository. " +
+    @Operation(summary = "Creates a new tornado, the newly created tornado is returned.",
+        description = "Additionally, a GeoTiff (raster) is created by default and publish to data repository. " +
             "User can create both model tornadoes and dataset-based tornadoes with GeoTiff files uploaded.")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "tornado", value = "Tornado json.", required = true, dataType = "string", paramType = "form"),
-        @ApiImplicitParam(name = "file", value = "Tornado files.", required = true, dataType = "string", paramType = "form")
+//    @ApiImplicitParams({
+//        @ApiImplicitParam(name = "tornado", value = "Tornado json.", required = true, dataType = "string", paramType = "form"),
+//        @ApiImplicitParam(name = "file", value = "Tornado files.", required = true, dataType = "string", paramType = "form")
+//    })
+    @Parameters({
+        @Parameter(name = "tornado", description = "Tornado json.", required = true, schema = @Schema(type = "string")),
+        @Parameter(name = "file", description = "Tornado files.", required = true, schema = @Schema(type = "string"))
     })
     public Tornado createTornado(
-        @ApiParam(hidden = true) @FormDataParam("tornado") String tornadoJson,
-        @ApiParam(hidden = true) @FormDataParam("file") List<FormDataBodyPart> fileParts) {
+        @Parameter(hidden = true) @FormDataParam("tornado") String tornadoJson,
+        @Parameter(hidden = true) @FormDataParam("file") List<FormDataBodyPart> fileParts) {
 
         // error messages for tornado creation
         String tornadoErrorMsg = "Could not create Tornado, check the format and files of your request. " +
@@ -296,9 +308,9 @@ public class TornadoController {
     @GET
     @Path("{tornado-id}")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns the tornado with matching id.")
+    @Operation(summary = "Returns the tornado with matching id.")
     public Tornado getTornado(
-        @ApiParam(value = "Tornado dataset guid from data service.", required = true) @PathParam("tornado-id") String tornadoId) {
+        @Parameter(name = "Tornado dataset guid from data service.", required = true) @PathParam("tornado-id") String tornadoId) {
 
         Tornado tornado = repository.getTornadoById(tornadoId);
         if (tornado == null) {
@@ -323,15 +335,15 @@ public class TornadoController {
     @GET
     @Path("{tornado-id}/value")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns the wind speed at given location using the specified tornado.")
+    @Operation(summary = "Returns the wind speed at given location using the specified tornado.")
     @Deprecated
     public WindHazardResult getTornadoHazard(
-        @ApiParam(value = "Tornado dataset guid from data service.", required = true) @PathParam("tornado-id") String tornadoId,
-        @ApiParam(value = "Tornado demand unit. Ex: 'm'.", required = true) @QueryParam("demandUnits") String demandUnits,
-        @ApiParam(value = "Latitude of a site. Ex: 35.027.", required = true) @QueryParam("siteLat") double siteLat,
-        @ApiParam(value = "Longitude of a site. Ex: -90.131.", required = true) @QueryParam("siteLong") double siteLong,
-        @ApiParam(value = "Simulated wind hazard. Ex: 0.") @QueryParam("simulation") @DefaultValue("0") int simulation,
-        @ApiParam(value = "Seed value for random values. Ex: 1000") @QueryParam("seed") @DefaultValue("-1") int seed) throws Exception {
+        @Parameter(name = "Tornado dataset guid from data service.", required = true) @PathParam("tornado-id") String tornadoId,
+        @Parameter(name = "Tornado demand unit. Ex: 'm'.", required = true) @QueryParam("demandUnits") String demandUnits,
+        @Parameter(name = "Latitude of a site. Ex: 35.027.", required = true) @QueryParam("siteLat") double siteLat,
+        @Parameter(name = "Longitude of a site. Ex: -90.131.", required = true) @QueryParam("siteLong") double siteLong,
+        @Parameter(name = "Simulated wind hazard. Ex: 0.") @QueryParam("simulation") @DefaultValue("0") int simulation,
+        @Parameter(name = "Seed value for random values. Ex: 1000") @QueryParam("seed") @DefaultValue("-1") int seed) throws Exception {
 
         Tornado tornado = getTornado(tornadoId);
         if (tornado != null) {
@@ -351,16 +363,16 @@ public class TornadoController {
     @Path("{tornado-id}/values")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns tornado values for a set of locations",
-        notes = "Outputs hazard values, demand types, unit and location.")
+    @Operation(summary = "Returns tornado values for a set of locations",
+        description = "Outputs hazard values, demand types, unit and location.")
     public List<ValuesResponse> postTornadoValues(
-        @ApiParam(value = "Tornado Id", required = true)
+        @Parameter(name = "Tornado Id", required = true)
         @PathParam("tornado-id") String tornadoId,
-        @ApiParam(value = "Json of the points along with demand types and units",
+        @Parameter(name = "Json of the points along with demand types and units",
             required = true) @FormDataParam("points") String requestJsonStr,
-        @ApiParam(value = "Simulated wind hazard index. Ex: 0 for first, 1 for second and so on")
+        @Parameter(name = "Simulated wind hazard index. Ex: 0 for first, 1 for second and so on")
         @FormDataParam("simulation") @DefaultValue("0") int simulation,
-        @ApiParam(value = "Seed value for random values. Ex: 1000")
+        @Parameter(name = "Seed value for random values. Ex: 1000")
         @FormDataParam("seed") @DefaultValue("-1") int seed) {
 
         Tornado tornado = getTornado(tornadoId);
@@ -444,9 +456,9 @@ public class TornadoController {
     @GET
     @Path("{tornado-id}/dataset")
     @Produces({MediaType.TEXT_PLAIN})
-    @ApiOperation(value = "Returns a zip shapefile representing tornado defined by given id.")
+    @Operation(summary = "Returns a zip shapefile representing tornado defined by given id.")
     public Response getFile(
-        @ApiParam(value = "Tornado dataset guid from data service.", required = true) @PathParam("tornado-id") String tornadoId) {
+        @Parameter(name = "Tornado dataset guid from data service.", required = true) @PathParam("tornado-id") String tornadoId) {
 
         // TODO implement this and change MediaType to Octet Stream
         return Response.ok("Shapefile representing tornado not yet implemented.").build();
@@ -455,16 +467,16 @@ public class TornadoController {
     @GET
     @Path("/search")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Search for a text in all tornadoes", notes = "Gets all tornadoes that contain a specific text")
+    @Operation(summary = "Search for a text in all tornadoes", description = "Gets all tornadoes that contain a specific text")
     @ApiResponses(value = {
-        @ApiResponse(code = 404, message = "No tornadoes found with the searched text")
+        @ApiResponse(responseCode = "404", description = "No tornadoes found with the searched text")
     })
     public List<Tornado> findTornadoes(
-        @ApiParam(value = "Text to search by", example = "building") @QueryParam("text") String text,
-        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
-        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
-        @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
-        @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+        @Parameter(name = "Text to search by", example = "building") @QueryParam("text") String text,
+        @Parameter(name = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @Parameter(name = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
+        @Parameter(name = "Skip the first n results") @QueryParam("skip") int offset,
+        @Parameter(name = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
 
         // import tornado comparator
         Comparator<Tornado> comparator = tornadoComparator(sortBy, order);
@@ -498,8 +510,8 @@ public class TornadoController {
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{tornado-id}")
-    @ApiOperation(value = "Deletes a tornado", notes = "Also deletes attached dataset and related files")
-    public Tornado deleteTornado(@ApiParam(value = "Tornado Id", required = true) @PathParam("tornado-id") String tornadoId) {
+    @Operation(summary = "Deletes a tornado", description = "Also deletes attached dataset and related files")
+    public Tornado deleteTornado(@Parameter(name = "Tornado Id", required = true) @PathParam("tornado-id") String tornadoId) {
         Tornado tornado = getTornado(tornadoId);
 
         if (authorizer.canUserDeleteMember(this.username, tornadoId, spaceRepository.getAllSpaces(), this.groups)) {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TsunamiController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TsunamiController.java
@@ -38,17 +38,12 @@ import edu.illinois.ncsa.incore.service.hazard.models.tsunami.types.TsunamiHazar
 import edu.illinois.ncsa.incore.service.hazard.models.tsunami.utils.TsunamiCalc;
 import edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.ServiceUtil;
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
-import io.swagger.v3.oas.annotations.info.Contact;
-import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.*;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -289,14 +284,15 @@ public class TsunamiController {
     @Operation(summary = "Creates a new tsunami, the newly created tsunami is returned.",
         description = "Additionally, a GeoTiff (raster) is created by default and publish to data repository. " +
             "User can create dataset-based tsunamis only.")
-//    @ApiImplicitParams({
-//        @ApiImplicitParam(name = "tsunami", value = "Tsunami json.", required = true, dataType = "string", paramType = "form"),
-//        @ApiImplicitParam(name = "file", value = "Tsunami files.", required = true, dataType = "string", paramType = "form")
-//    })
-    @Parameters({
-        @Parameter(name = "tsunami", description = "Tsunami json.", required = true, schema = @Schema(type = "string")),
-        @Parameter(name = "file", description = "Tsunami files.", required = true, schema = @Schema(type = "string"))
-    })
+
+    @RequestBody(description = "Tsunami json and files.", required = true,
+        content = @Content(mediaType = MediaType.APPLICATION_FORM_URLENCODED,
+            schema = @Schema(type = "object",
+                properties = {@StringToClassMapItem(key = "tsunami", value = String.class),
+                    @StringToClassMapItem(key = "file", value = String.class)}
+            )
+        )
+    )
     public Tsunami createTsunami(
         @Parameter(hidden = true) @FormDataParam("tsunami") String tsunamiJson,
         @Parameter(hidden = true) @FormDataParam("file") List<FormDataBodyPart> fileParts) {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TsunamiController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TsunamiController.java
@@ -44,6 +44,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -68,6 +69,7 @@ import java.util.stream.Collectors;
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.*;
 import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.tsunamiComparator;
 
+@Tag(name = "tsunamis")
 
 @Path("tsunamis")
 @ApiResponses(value = {

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TsunamiController.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/controllers/TsunamiController.java
@@ -38,7 +38,21 @@ import edu.illinois.ncsa.incore.service.hazard.models.tsunami.types.TsunamiHazar
 import edu.illinois.ncsa.incore.service.hazard.models.tsunami.utils.TsunamiCalc;
 import edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil;
 import edu.illinois.ncsa.incore.service.hazard.utils.ServiceUtil;
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.log4j.Logger;
 import org.glassfish.jersey.media.multipart.BodyPartEntity;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
@@ -46,10 +60,6 @@ import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import javax.inject.Inject;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -61,14 +71,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static edu.illinois.ncsa.incore.service.hazard.models.eq.utils.HazardUtil.*;
-import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.tornadoComparator;
 import static edu.illinois.ncsa.incore.service.hazard.utils.CommonUtil.tsunamiComparator;
 
-@Api(value = "tsunamis", authorizations = {})
 
 @Path("tsunamis")
 @ApiResponses(value = {
-    @ApiResponse(code = 500, message = "Internal Server Error.")
+    @ApiResponse(responseCode = "500", description = "Internal Server Error")
 })
 public class TsunamiController {
     private static final Logger log = Logger.getLogger(TsunamiController.class);
@@ -96,8 +104,8 @@ public class TsunamiController {
 
     @Inject
     public TsunamiController(
-        @ApiParam(value = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
-        @ApiParam(value = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups
+        @Parameter(name = "User credentials.", required = true) @HeaderParam("x-auth-userinfo") String userInfo,
+        @Parameter(name = "User groups.", required = false) @HeaderParam("x-auth-usergroup") String userGroups
     ) {
         this.userGroups = userGroups;
         this.username = UserInfoUtils.getUsername(userInfo);
@@ -106,13 +114,13 @@ public class TsunamiController {
 
     @GET
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns all tsunamis.")
+    @Operation(summary = "Returns all tsunamis.")
     public List<Tsunami> getTsunamis(
-        @ApiParam(value = "Space name") @DefaultValue("") @QueryParam("space") String spaceName,
-        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
-        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
-        @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
-        @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+        @Parameter(name = "Space name") @DefaultValue("") @QueryParam("space") String spaceName,
+        @Parameter(name = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @Parameter(name = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
+        @Parameter(name = "Skip the first n results") @QueryParam("skip") int offset,
+        @Parameter(name = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
 
         // import tsunami comparator
         Comparator<Tsunami> comparator = tsunamiComparator(sortBy, order);
@@ -161,9 +169,9 @@ public class TsunamiController {
     @GET
     @Path("{tsunami-id}")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns the scenario tsunami matching the given id.")
+    @Operation(summary = "Returns the scenario tsunami matching the given id.")
     public Tsunami getTsunami(
-        @ApiParam(value = "Tsunami dataset guid from data service.", required = true) @PathParam("tsunami-id") String tsunamiId) {
+        @Parameter(name = "Tsunami dataset guid from data service.", required = true) @PathParam("tsunami-id") String tsunamiId) {
 
         Tsunami tsunami = repository.getTsunamiById(tsunamiId);
 
@@ -184,12 +192,12 @@ public class TsunamiController {
     @Path("{tsunami-id}/values")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Returns tsunami values for a set of locations",
-        notes = "Outputs hazard values, demand types, unit and location.")
+    @Operation(summary = "Returns tsunami values for a set of locations",
+        description = "Outputs hazard values, demand types, unit and location.")
     public List<ValuesResponse> postTsunamiValues(
-        @ApiParam(value = "Tsunami Id", required = true)
+        @Parameter(name = "Tsunami Id", required = true)
         @PathParam("tsunami-id") String tsunamiId,
-        @ApiParam(value = "Json of the points along with demand types and units",
+        @Parameter(name = "Json of the points along with demand types and units",
             required = true) @FormDataParam("points") String requestJsonStr) {
 
         Tsunami tsunami = getTsunami(tsunamiId);
@@ -278,16 +286,20 @@ public class TsunamiController {
     @POST
     @Consumes({MediaType.MULTIPART_FORM_DATA})
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Creates a new tsunami, the newly created tsunami is returned.",
-        notes = "Additionally, a GeoTiff (raster) is created by default and publish to data repository. " +
+    @Operation(summary = "Creates a new tsunami, the newly created tsunami is returned.",
+        description = "Additionally, a GeoTiff (raster) is created by default and publish to data repository. " +
             "User can create dataset-based tsunamis only.")
-    @ApiImplicitParams({
-        @ApiImplicitParam(name = "tsunami", value = "Tsunami json.", required = true, dataType = "string", paramType = "form"),
-        @ApiImplicitParam(name = "file", value = "Tsunami files.", required = true, dataType = "string", paramType = "form")
+//    @ApiImplicitParams({
+//        @ApiImplicitParam(name = "tsunami", value = "Tsunami json.", required = true, dataType = "string", paramType = "form"),
+//        @ApiImplicitParam(name = "file", value = "Tsunami files.", required = true, dataType = "string", paramType = "form")
+//    })
+    @Parameters({
+        @Parameter(name = "tsunami", description = "Tsunami json.", required = true, schema = @Schema(type = "string")),
+        @Parameter(name = "file", description = "Tsunami files.", required = true, schema = @Schema(type = "string"))
     })
     public Tsunami createTsunami(
-        @ApiParam(hidden = true) @FormDataParam("tsunami") String tsunamiJson,
-        @ApiParam(hidden = true) @FormDataParam("file") List<FormDataBodyPart> fileParts) {
+        @Parameter(hidden = true) @FormDataParam("tsunami") String tsunamiJson,
+        @Parameter(hidden = true) @FormDataParam("file") List<FormDataBodyPart> fileParts) {
 
         // check if the user's number of the hazard is within the allocation
         if (!AllocationUtils.canCreateAnyDataset(allocationsRepository, quotaRepository, this.username, "hazards")) {
@@ -380,8 +392,8 @@ public class TsunamiController {
     @DELETE
     @Produces(MediaType.APPLICATION_JSON)
     @Path("{tsunami-id}")
-    @ApiOperation(value = "Deletes a Tsunami", notes = "Also deletes attached dataset and related files")
-    public Tsunami deleteTsunami(@ApiParam(value = "Tsunami Id", required = true) @PathParam("tsunami-id") String tsunamiId) {
+    @Operation(summary = "Deletes a Tsunami", description = "Also deletes attached dataset and related files")
+    public Tsunami deleteTsunami(@Parameter(name = "Tsunami Id", required = true) @PathParam("tsunami-id") String tsunamiId) {
         Tsunami tsunami = getTsunami(tsunamiId);
 
         if (authorizer.canUserDeleteMember(this.username, tsunamiId, spaceRepository.getAllSpaces(), this.groups)) {
@@ -419,16 +431,16 @@ public class TsunamiController {
     @GET
     @Path("/search")
     @Produces({MediaType.APPLICATION_JSON})
-    @ApiOperation(value = "Search for a text in all tsunamis", notes = "Gets all tsunamis that contain a specific text")
+    @Operation(summary = "Search for a text in all tsunamis", description = "Gets all tsunamis that contain a specific text")
     @ApiResponses(value = {
-        @ApiResponse(code = 404, message = "No tsunamis found with the searched text")
+        @ApiResponse(responseCode = "404", description = "No tsunamis found with the searched text")
     })
     public List<Tsunami> findTsunamis(
-        @ApiParam(value = "Text to search by", example = "building") @QueryParam("text") String text,
-        @ApiParam(value = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
-        @ApiParam(value = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
-        @ApiParam(value = "Skip the first n results") @QueryParam("skip") int offset,
-        @ApiParam(value = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
+        @Parameter(name = "Text to search by", example = "building") @QueryParam("text") String text,
+        @Parameter(name = "Specify the field or attribute on which the sorting is to be performed.") @DefaultValue("date") @QueryParam("sortBy") String sortBy,
+        @Parameter(name = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
+        @Parameter(name = "Skip the first n results") @QueryParam("skip") int offset,
+        @Parameter(name = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit) {
 
         // import tsunami comparator
         Comparator<Tsunami> comparator = tsunamiComparator(sortBy, order);

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/dao/DBHurricaneRepository.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/dao/DBHurricaneRepository.java
@@ -16,7 +16,7 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/EarthquakeDataset.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/EarthquakeDataset.java
@@ -7,12 +7,12 @@
 package edu.illinois.ncsa.incore.service.hazard.models.eq;
 
 import dev.morphia.annotations.Entity;
-import io.swagger.annotations.ApiModel;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.LinkedList;
 import java.util.List;
 
-@ApiModel(value = "Earthquake dataset", description = "Contains id, description, name, privileges and the hazard datasets")
+@Schema(name = "Earthquake dataset", description = "Contains id, description, name, privileges and the hazard datasets")
 @Entity("EarthquakeDataset")
 public class EarthquakeDataset extends Earthquake {
 

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/hurricane/utils/GISHurricaneUtils.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/hurricane/utils/GISHurricaneUtils.java
@@ -45,7 +45,7 @@ import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.NoSuchAuthorityCodeException;
 import org.opengis.referencing.operation.TransformException;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.io.*;
 import java.nio.file.Files;
 import java.util.*;

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/hurricaneWindfields/utils/HurricaneWindfieldsCalc.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/hurricaneWindfields/utils/HurricaneWindfieldsCalc.java
@@ -30,7 +30,7 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ForkJoinPool;

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/utils/CommonUtil.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/utils/CommonUtil.java
@@ -10,7 +10,7 @@ import edu.illinois.ncsa.incore.service.hazard.models.tornado.Tornado;
 import edu.illinois.ncsa.incore.service.hazard.models.tsunami.Tsunami;
 import org.json.simple.JSONObject;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.util.Comparator;
 import java.util.List;
 

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/utils/GISUtil.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/utils/GISUtil.java
@@ -28,7 +28,7 @@ import org.opengis.coverage.grid.GridCoverage;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 import java.io.*;
 import java.net.URL;
 import java.util.HashMap;

--- a/server/hazard-service/src/main/webapp/WEB-INF/web.xml
+++ b/server/hazard-service/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
          id="WebApp_ID"
-         version="2.5">
+         version="3.0">
     <display-name>Hazard Service</display-name>
 
 
@@ -11,16 +11,23 @@
         <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
 
         <init-param>
-            <param-name>javax.ws.rs.Application</param-name>
+            <param-name>jersey.config.server.wadl.disableWadl</param-name>
+            <param-value>true</param-value>
+        </init-param>
+        <init-param>
+            <param-name>jakarta.ws.rs.Application</param-name>
             <param-value>edu.illinois.ncsa.incore.service.hazard.Application</param-value>
         </init-param>
-
         <init-param>
             <param-name>jersey.config.server.provider.packages</param-name>
             <param-value>
-                edu.illinois.ncsa.incore.service.hazard.controllers,
-                io.swagger.jaxrs.listing
+                edu.illinois.ncsa.incore.service.hazard.controllers
+                io.swagger.v3.jaxrs2.integration.resources
             </param-value>
+        </init-param>
+        <init-param>
+            <param-name>openApi.configuration.prettyPrint</param-name>
+            <param-value>true</param-value>
         </init-param>
         <init-param>
             <param-name>jersey.config.server.provider.classnames</param-name>
@@ -37,16 +44,12 @@
     </servlet-mapping>
 
     <servlet>
-        <servlet-name>Jersey2Config</servlet-name>
-        <servlet-class>io.swagger.jersey.config.JerseyJaxrsConfig</servlet-class>
-        <init-param>
-            <param-name>api.version</param-name>
-            <param-value>1.2.1</param-value>
-        </init-param>
-        <init-param>
-            <param-name>swagger.api.basepath</param-name>
-            <param-value>/hazard/api</param-value>
-        </init-param>
-        <load-on-startup>2</load-on-startup>
+        <servlet-name>OpenApi</servlet-name>
+        <servlet-class>io.swagger.v3.jaxrs2.integration.OpenApiServlet</servlet-class>
     </servlet>
+
+    <servlet-mapping>
+        <servlet-name>OpenApi</servlet-name>
+        <url-pattern>/openapi/*</url-pattern>
+    </servlet-mapping>
 </web-app>

--- a/server/hazard-service/src/main/webapp/WEB-INF/web.xml
+++ b/server/hazard-service/src/main/webapp/WEB-INF/web.xml
@@ -3,13 +3,10 @@
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
          id="WebApp_ID"
          version="3.0">
-    <display-name>Hazard Service</display-name>
-
-
+    <display-name>InCore Hazard Service</display-name>
     <servlet>
-        <servlet-name>hazard</servlet-name>
+        <servlet-name>Jersey Web Application</servlet-name>
         <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
-
         <init-param>
             <param-name>jersey.config.server.wadl.disableWadl</param-name>
             <param-value>true</param-value>
@@ -35,11 +32,10 @@
                 org.glassfish.jersey.jackson.JacksonFeature;org.glassfish.jersey.media.multipart.MultiPartFeature
             </param-value>
         </init-param>
-
         <load-on-startup>1</load-on-startup>
     </servlet>
     <servlet-mapping>
-        <servlet-name>hazard</servlet-name>
+        <servlet-name>Jersey Web Application</servlet-name>
         <url-pattern>/api/*</url-pattern>
     </servlet-mapping>
 


### PR DESCRIPTION
Changed these annotations following the docs: [Migrating from SpringFox](https://springdoc.org/migrating-from-springfox.html) and [Describing Request Body](https://swagger.io/docs/specification/describing-request-body/)
Here are the annotations different from PR #152:
```
@Api → @Tag
@ApiResponse(code = 404, message = "foo") → @ApiResponse(responseCode = "404", description = "foo")
@ApiImplicitParam → @RequestBody
@ApiModel → @Schema
```
For testing, please test the following after running hazard service:
1. Check the swagger doc
http://localhost:8080/hazard/api/openapi.json
2. Test endpoints
[GET] http://localhost:8080/hazard/api/floods/
[GET] http://localhost:8080/hazard/api/tsunamis/5bc9eaf7f7b08533c7e610e1
[GET] http://localhost:8080/hazard/api/hurricanes/search?text=a
[POST] http://localhost:8080/hazard/api/earthquakes
[DELETE] http://localhost:8080/hazard/api/earthquakes/5c62e727c11bb30659444248

Scripts for testing using curl: (copy paste friendly if you are using your local mongodb)
```
curl -i -X GET \
   -H "x-auth-userinfo:{\"preferred_username\":\"commresilience\"}" \
   -H "x-auth-usergroup:{\"groups\":[\"incore_admin\"]}" \
 'http://localhost:8080/hazard/api/floods'

curl -i -X GET \
   -H "x-auth-userinfo:{\"preferred_username\":\"commresilience\"}" \
   -H "x-auth-usergroup:{\"groups\":[\"incore_admin\"]}" \
 'http://localhost:8080/hazard/api/tsunamis/5bc9eaf7f7b08533c7e610e1'

curl -i -X GET \
   -H "x-auth-userinfo:{\"preferred_username\":\"commresilience\"}" \
   -H "x-auth-usergroup:{\"groups\":[\"incore_admin\"]}" \
 'http://localhost:8080/hazard/api/hurricanes/search?text=a'

curl --location 'http://localhost:8080/hazard/api/earthquakes' \
--header 'x-auth-userinfo: {"preferred_username":"commresilience"}' \
--header 'x-auth-usergroup: {"groups": ["incore_admin"]}' \
--form 'earthquake="{
   \"name\":\"yytest\",
   \"description\":\"yytest\",
   \"eqType\":\"model\",
   \"attenuations\":{
      \"ChiouYoungs2014\":\"1.0\"
   },
   \"eqParameters\":{
      \"srcLatitude\":40.177,
      \"srcLongitude\":-111.426,
      \"magnitude\":\"5.5\",
      \"depth\":\"11.2\",
      \"region\":\"\",
      \"faultTypeMap\":{
         \"ChiouYoungs2014\":\"Normal\"
      }
   },
   \"visualizationParameters\":{
      \"demandType\":\"PGA\",
      \"demandUnits\":\"g\",
      \"minX\":-112.312,
      \"minY\":40.277,
      \"maxX\":-111.462,
      \"maxY\":41,
     
      \"numPoints\":\"1025\",
      \"amplifyHazard\":\"true\"
   }
}"'

curl --location --request DELETE 'http://localhost:8080/hazard/api/earthquakes/5c62e727c11bb30659444248' \
--header 'x-auth-userinfo: {"preferred_username":"commresilience"}' \
--header 'x-auth-usergroup: {"groups": ["incore_admin"]}'
```