### PR TITLE
Added freemarker template for types and an endpoint to return type as html

### DIFF
--- a/server/semantics-service/build.gradle
+++ b/server/semantics-service/build.gradle
@@ -4,6 +4,7 @@ gretty {
 }
 
 dependencies {
+    implementation group: 'org.freemarker', name: 'freemarker', version: '2.3.32'
     implementation group: 'org.apache.jena', name: 'jena-core', version: '3.1.1'
     implementation project(':semantic-core')
 }

--- a/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/model/Column.java
+++ b/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/model/Column.java
@@ -8,40 +8,26 @@ public class Column {
 
     private String name;
     private String titles;
-    private String dataType;
+    private String datatype;
 
-    @Property("incore:agg-type")
-    private String aggType;
+    @Property("dc:description")
+    private String description;
 
-    @Property("incore:field-length")
-    private Integer fieldLength;
-
-    @Property("incore:importance")
-    private String importance;
-
-    @Property("incore:is-numeric")
-    private String isNumeric;
-
-    @Property("incore:is-result")
-    private String isResult;
-
-    @Property("incore:unit")
+    @Property("qudt:unit")
     private String unit;
+
+    private String required;
 
     public Column() {
     }
 
-    public Column(String name, String titles, String dataType, String aggType, Integer fieldLength,
-                  String importance, String isNumeric, String isResult, String unit) {
+    public Column(String name, String titles, String datatype, String description, String unit, String required) {
         this.name = name;
         this.titles = titles;
-        this.dataType = dataType;
-        this.aggType = aggType;
-        this.fieldLength = fieldLength;
-        this.importance = importance;
-        this.isNumeric = isNumeric;
-        this.isResult = isResult;
+        this.datatype = datatype;
+        this.description = description;
         this.unit = unit;
+        this.required = required;
     }
 
     public String getName() {
@@ -52,31 +38,15 @@ public class Column {
         return this.titles;
     }
 
-    public String getDataType() {
-        return this.dataType;
-    }
-
-    public String getAggType() {
-        return aggType;
-    }
-
-    public Integer getFieldLength() {
-        return fieldLength;
-    }
-
-    public String getImportance() {
-        return importance;
-    }
-
-    public String getIsNumeric() {
-        return isNumeric;
-    }
-
-    public String getIsResult() {
-        return isResult;
+    public String getDatatype() {
+        return this.datatype;
     }
 
     public String getUnit() {
         return unit;
     }
+
+    public String getDescription() { return description; }
+
+    public String getRequired(){ return required; }
 }

--- a/server/semantics-service/src/main/resources/templates/freemarker/types.ftl
+++ b/server/semantics-service/src/main/resources/templates/freemarker/types.ftl
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<head>
+    <title>Type Description</title>
+    <style>
+        table {
+            font-family: arial, sans-serif;
+            border-collapse: collapse;
+            width: 100%;
+        }
+
+        td, th {
+            border: 1px solid #dddddd;
+            text-align: left;
+            padding: 8px;
+        }
+
+        tr:nth-child(even) {
+            background-color: #dddddd;
+        }
+
+        div {
+            padding-top: 20px;
+            padding-right: 220px;
+            padding-bottom: 20px;
+            padding-left: 20px;
+        }
+    </style>
+</head>
+<body>
+<div>
+    <h1>${title}</h1>
+
+    <p><strong>Description</strong></p>
+    <p>Each schema defines the expected attributes for a dataset definition. The attributes for the <b>${title}</b>
+        schema are listed in the table below.</p>
+
+    <table>
+        <tr>
+            <th>Parameter</th>
+            <th>Value</th>
+        </tr>
+        <#list items?keys as key>
+            <tr>
+                <td>${key}</td>
+                <td>${items[key]} </td>
+            </tr>
+        </#list>
+    </table>
+</div>
+</body>
+</html>

--- a/server/semantics-service/src/main/resources/templates/freemarker/types.ftl
+++ b/server/semantics-service/src/main/resources/templates/freemarker/types.ftl
@@ -1,48 +1,48 @@
 <!DOCTYPE html>
 <head>
     <title>Type Description</title>
+    <link rel="stylesheet"
+          href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css"
+          integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm"
+          crossorigin="anonymous">
     <style>
-        table {
-            font-family: arial, sans-serif;
-            border-collapse: collapse;
-            width: 100%;
+        body {
+            font-size: 12px;
+            line-height: 1.4em;
+            min-width: 230px;
+            margin: 0 auto;
+            -webkit-font-smoothing: antialiased;
+            font-weight: 300;
+            height:100%;
         }
-
-        td, th {
-            border: 1px solid #dddddd;
-            text-align: left;
-            padding: 8px;
-        }
-
-        tr:nth-child(even) {
-            background-color: #dddddd;
-        }
-
         div {
-            padding-top: 20px;
-            padding-right: 220px;
-            padding-bottom: 20px;
-            padding-left: 20px;
+            padding: 2em 5em;
         }
     </style>
 </head>
 <body>
 <div>
-    <h1>${title}</h1>
-
-    <p><strong>Description</strong></p>
-    <p>Each schema defines the expected attributes for a dataset definition. The attributes for the <b>${title}</b>
+    <h1 class="display-4">${title}</h1>
+    <p class="lead">${description}</p>
+    <p class="text-muted">Each schema defines the expected attributes for a dataset definition.
+        The attributes for the <b>${title}</b>
         schema are listed in the table below.</p>
 
-    <table>
-        <tr>
-            <th>Parameter</th>
-            <th>Value</th>
+    <table class="table">
+        <tr style="background: #eee;">
+            <th scope="col">Name</th>
+            <th scope="col">Titles</th>
+            <th scope="col">Datatype</th>
+            <th scope="col">Unit</th>
+            <th scope="col">Required</th>
         </tr>
-        <#list items?keys as key>
+        <#list columns as column>
             <tr>
-                <td>${key}</td>
-                <td>${items[key]} </td>
+                <th scope="row">${column.name}</th>
+                <td>${column.titles}</td>
+                <td>${column.datatype}</td>
+                <td>${column.unit}</td>
+                <td>${column.required}</td>
             </tr>
         </#list>
     </table>


### PR DESCRIPTION
Created an example template file that can be used to pass each semantic type as html. The template is basic and could be cleaned up. For example, the tableSchema is a nested set of documents that could be parsed separately into another object that displays the tableSchema more cleanly. 