### PR TITLE
Fixed #148 - missing log4j in some services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Refactor DAO for Semantics service [#151](https://github.com/IN-CORE/incore-services/issues/151)
 - Removed jetty-runner 9 and replaced with Jetty 11 docker image [#174](https://github.com/IN-CORE/incore-services/issues/174)
 
+### Fixed
+- Missing log4j.properties file required to configure logging [#148](https://github.com/IN-CORE/incore-services/issues/148)
+
 ## [1.14.0] -2023-06-14
 ### Added
 - Query parameters for sorting by given field in ascending and descending order [#111](https://github.com/IN-CORE/incore-services/issues/111)

--- a/server/data-service/src/main/resources/log4j.properties
+++ b/server/data-service/src/main/resources/log4j.properties
@@ -1,0 +1,22 @@
+log4j.debug=true
+#Log Levels = (Most) DEBUG,INFO,WARN,ERROR,FATAL (Least) or ALL to obtain all logs
+# set root logger to debug level to output to the standard output/console appender
+log4j.threshold=ALL
+log4j.rootLogger=ALL, incore, error
+log4j.logger.net.jayray=DEBUG
+# this defines the "F" (file) appender to be used with the root logger.  The "F" is an arbitrary name.  It specifies to send data to log file
+log4j.appender.incore=org.apache.log4j.RollingFileAppender
+log4j.appender.incore.File=${user.home}/incore.log
+log4j.appender.incore.MaxFileSize=10MB
+log4j.appender.incore.MaxBackupIndex=10
+log4j.appender.incore.layout=org.apache.log4j.PatternLayout
+log4j.appender.incore.Threshold=DEBUG
+log4j.appender.incore.layout.ConversionPattern=[%d{MM-dd-yyyy HH:mm:ss,SSS}][%t][%-5p]%-50.50c: %m%n
+# this defines the "F" (file) appender to be used with the root logger.  The "F" is an arbitrary name.  It specifies to send data to log file
+log4j.appender.error=org.apache.log4j.RollingFileAppender
+log4j.appender.error.File=${user.home}/incore-error.log
+log4j.appender.error.MaxFileSize=10MB
+log4j.appender.error.MaxBackupIndex=10
+log4j.appender.error.layout=org.apache.log4j.PatternLayout
+log4j.appender.error.Threshold=ERROR
+log4j.appender.error.layout.ConversionPattern=[%d{MM-dd-yyyy HH:mm:ss,SSS}][%t][%-5p]%-50.50c: %m%n

--- a/server/hazard-service/src/main/resources/log4j.properties
+++ b/server/hazard-service/src/main/resources/log4j.properties
@@ -1,0 +1,22 @@
+log4j.debug=true
+#Log Levels = (Most) DEBUG,INFO,WARN,ERROR,FATAL (Least) or ALL to obtain all logs
+# set root logger to debug level to output to the standard output/console appender
+log4j.threshold=ALL
+log4j.rootLogger=ALL, incore, error
+log4j.logger.net.jayray=DEBUG
+# this defines the "F" (file) appender to be used with the root logger.  The "F" is an arbitrary name.  It specifies to send data to log file
+log4j.appender.incore=org.apache.log4j.RollingFileAppender
+log4j.appender.incore.File=${user.home}/incore.log
+log4j.appender.incore.MaxFileSize=10MB
+log4j.appender.incore.MaxBackupIndex=10
+log4j.appender.incore.layout=org.apache.log4j.PatternLayout
+log4j.appender.incore.Threshold=DEBUG
+log4j.appender.incore.layout.ConversionPattern=[%d{MM-dd-yyyy HH:mm:ss,SSS}][%t][%-5p]%-50.50c: %m%n
+# this defines the "F" (file) appender to be used with the root logger.  The "F" is an arbitrary name.  It specifies to send data to log file
+log4j.appender.error=org.apache.log4j.RollingFileAppender
+log4j.appender.error.File=${user.home}/incore-error.log
+log4j.appender.error.MaxFileSize=10MB
+log4j.appender.error.MaxBackupIndex=10
+log4j.appender.error.layout=org.apache.log4j.PatternLayout
+log4j.appender.error.Threshold=ERROR
+log4j.appender.error.layout.ConversionPattern=[%d{MM-dd-yyyy HH:mm:ss,SSS}][%t][%-5p]%-50.50c: %m%n

--- a/server/semantics-service/src/main/resources/log4j.properties
+++ b/server/semantics-service/src/main/resources/log4j.properties
@@ -1,0 +1,22 @@
+log4j.debug=true
+#Log Levels = (Most) DEBUG,INFO,WARN,ERROR,FATAL (Least) or ALL to obtain all logs
+# set root logger to debug level to output to the standard output/console appender
+log4j.threshold=ALL
+log4j.rootLogger=ALL, incore, error
+log4j.logger.net.jayray=DEBUG
+# this defines the "F" (file) appender to be used with the root logger.  The "F" is an arbitrary name.  It specifies to send data to log file
+log4j.appender.incore=org.apache.log4j.RollingFileAppender
+log4j.appender.incore.File=${user.home}/incore.log
+log4j.appender.incore.MaxFileSize=10MB
+log4j.appender.incore.MaxBackupIndex=10
+log4j.appender.incore.layout=org.apache.log4j.PatternLayout
+log4j.appender.incore.Threshold=DEBUG
+log4j.appender.incore.layout.ConversionPattern=[%d{MM-dd-yyyy HH:mm:ss,SSS}][%t][%-5p]%-50.50c: %m%n
+# this defines the "F" (file) appender to be used with the root logger.  The "F" is an arbitrary name.  It specifies to send data to log file
+log4j.appender.error=org.apache.log4j.RollingFileAppender
+log4j.appender.error.File=${user.home}/incore-error.log
+log4j.appender.error.MaxFileSize=10MB
+log4j.appender.error.MaxBackupIndex=10
+log4j.appender.error.layout=org.apache.log4j.PatternLayout
+log4j.appender.error.Threshold=ERROR
+log4j.appender.error.layout.ConversionPattern=[%d{MM-dd-yyyy HH:mm:ss,SSS}][%t][%-5p]%-50.50c: %m%n

--- a/server/space-service/src/main/resources/log4j.properties
+++ b/server/space-service/src/main/resources/log4j.properties
@@ -1,0 +1,22 @@
+log4j.debug=true
+#Log Levels = (Most) DEBUG,INFO,WARN,ERROR,FATAL (Least) or ALL to obtain all logs
+# set root logger to debug level to output to the standard output/console appender
+log4j.threshold=ALL
+log4j.rootLogger=ALL, incore, error
+log4j.logger.net.jayray=DEBUG
+# this defines the "F" (file) appender to be used with the root logger.  The "F" is an arbitrary name.  It specifies to send data to log file
+log4j.appender.incore=org.apache.log4j.RollingFileAppender
+log4j.appender.incore.File=${user.home}/incore.log
+log4j.appender.incore.MaxFileSize=10MB
+log4j.appender.incore.MaxBackupIndex=10
+log4j.appender.incore.layout=org.apache.log4j.PatternLayout
+log4j.appender.incore.Threshold=DEBUG
+log4j.appender.incore.layout.ConversionPattern=[%d{MM-dd-yyyy HH:mm:ss,SSS}][%t][%-5p]%-50.50c: %m%n
+# this defines the "F" (file) appender to be used with the root logger.  The "F" is an arbitrary name.  It specifies to send data to log file
+log4j.appender.error=org.apache.log4j.RollingFileAppender
+log4j.appender.error.File=${user.home}/incore-error.log
+log4j.appender.error.MaxFileSize=10MB
+log4j.appender.error.MaxBackupIndex=10
+log4j.appender.error.layout=org.apache.log4j.PatternLayout
+log4j.appender.error.Threshold=ERROR
+log4j.appender.error.layout.ConversionPattern=[%d{MM-dd-yyyy HH:mm:ss,SSS}][%t][%-5p]%-50.50c: %m%n


### PR DESCRIPTION
Some services were missing a log4j.properties file to configure the log4j logger. When a debug/warn/error statement was called, there would be a message in the console to initialize log4j and no message would print in the logger. This should be fixed now. You can test by either hitting an endpoint that prints a log message or add some test logging messages somewhere (e.g. in the controller constructor) and check the incore.log file. You should see the debug/warn/error message you either added or hit.