### PR TITLE
206 show description instead of title for semantics table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Geoserver connection library has been removed and new connection object has been added [#190](https://github.com/IN-CORE/incore-services/issues/190)
+- Semantics should display description instead of title [#206](https://github.com/IN-CORE/incore-services/issues/206)
 
 ## [1.20.0] - 2023-08-16
 

--- a/server/semantics-service/src/main/resources/templates/freemarker/types.ftl
+++ b/server/semantics-service/src/main/resources/templates/freemarker/types.ftl
@@ -31,7 +31,7 @@
     <table class="table">
         <tr style="background: #eee;">
             <th scope="col">Name</th>
-            <th scope="col">Titles</th>
+            <th scope="col">Description</th>
             <th scope="col">Datatype</th>
             <th scope="col">Unit</th>
             <th scope="col">Required</th>
@@ -39,7 +39,7 @@
         <#list columns as column>
             <tr>
                 <th scope="row">${column.name}</th>
-                <td>${column.titles}</td>
+                <td>${column.description}</td>
                 <td>${column.datatype}</td>
                 <td>${column.unit}</td>
                 <td>${column.required}</td>


### PR DESCRIPTION
A small change since I notice description has more details we should display that instead of titles