### PR TITLE
217 add jupyter quota to incore service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Attenuation model Sadigh et al. 1997 [#208](https://github.com/IN-CORE/incore-services/issues/208)
+- Include incore lab quota to the allocation endpoints [#217](https://github.com/IN-CORE/incore-services/issues/217)
 
 ### Changed
 - Geoserver connection library has been removed and new connection object has been added [#190](https://github.com/IN-CORE/incore-services/issues/190)

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/IncoreLabQuota.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/IncoreLabQuota.java
@@ -1,0 +1,53 @@
+package edu.illinois.ncsa.incore.common.models;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dev.morphia.annotations.Embedded;
+import org.json.JSONObject;
+
+import java.util.List;
+
+@Embedded
+public class IncoreLabQuota {
+    public List<Integer> cpu;
+    public List<Integer> mem;
+    public int disk;
+
+    public IncoreLabQuota(){ }
+
+    public JSONObject toJson() {
+        JSONObject outJson = new JSONObject();
+
+        outJson.put("cpu", this.cpu);
+        outJson.put("mem", this.mem);
+        outJson.put("disk", this.disk);
+
+        return outJson;
+    }
+
+    public List<Integer> getCpu() {
+        return this.cpu;
+    }
+
+    public void setCpu(List<Integer> cpu) {
+        this.cpu = cpu;
+    }
+
+    public List<Integer> getMem(){
+        return this.mem;
+    }
+
+    public void setMem(List<Integer> mem) {
+        this.mem = mem;
+    }
+
+    public int getDisk() {
+        return this.disk;
+    }
+
+    public void setDisk(int disk){
+        this.disk = disk;
+    }
+
+}

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/UserUsages.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/UserUsages.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.morphia.annotations.Embedded;
 import org.apache.log4j.Logger;
 
+import java.util.List;
+
 @Embedded
 public class UserUsages {
     private static final Logger log = Logger.getLogger(UserUsages.class);
@@ -24,6 +26,14 @@ public class UserUsages {
     public int dfr3;
     public long datasetSize;
     public long hazardDatasetSize;
+//    "cpu": [ 4, 16 ],
+//         "mem": [ 8, 32 ],
+//         "disk": 512,
+//         "service": [ 200, 5 ]
+    public List<Integer> cpu;
+    public List<Integer> mem;
+    public int disk;
+    public List<Integer> service;
 
     public UserUsages() { }
 
@@ -83,5 +93,37 @@ public class UserUsages {
 
     public void setHazardDatasetSize(long hazardDatasetSize) {
         this.hazardDatasetSize = hazardDatasetSize;
+    }
+
+    public List<Integer> getCpu() {
+        return this.cpu;
+    }
+
+    public void setCpu(List<Integer> cpu) {
+        this.cpu = cpu;
+    }
+
+    public List<Integer> getMem(){
+        return this.mem;
+    }
+
+    public void setMem(List<Integer> mem) {
+        this.mem = mem;
+    }
+
+    public int getDisk() {
+        return this.disk;
+    }
+
+    public void setDisk(int disk){
+        this.disk = disk;
+    }
+
+    public List<Integer> getService() {
+        return this.service;
+    }
+
+    public void setService(List<Integer> service){
+        this.service = service;
     }
 }

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/UserUsages.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/UserUsages.java
@@ -16,6 +16,7 @@ import org.apache.log4j.Logger;
 
 import java.util.List;
 
+
 @Embedded
 public class UserUsages {
     private static final Logger log = Logger.getLogger(UserUsages.class);
@@ -26,10 +27,8 @@ public class UserUsages {
     public int dfr3;
     public long datasetSize;
     public long hazardDatasetSize;
-    public List<Integer> cpu;
-    public List<Integer> mem;
-    public int disk;
     public List<Integer> service;
+    public IncoreLabQuota incoreLab;
 
     public UserUsages() { }
 
@@ -91,28 +90,12 @@ public class UserUsages {
         this.hazardDatasetSize = hazardDatasetSize;
     }
 
-    public List<Integer> getCpu() {
-        return this.cpu;
+    public IncoreLabQuota getIncoreLab(){
+        return this.incoreLab;
     }
 
-    public void setCpu(List<Integer> cpu) {
-        this.cpu = cpu;
-    }
-
-    public List<Integer> getMem(){
-        return this.mem;
-    }
-
-    public void setMem(List<Integer> mem) {
-        this.mem = mem;
-    }
-
-    public int getDisk() {
-        return this.disk;
-    }
-
-    public void setDisk(int disk){
-        this.disk = disk;
+    public void setIncoreLab(IncoreLabQuota incoreLab){
+        this.incoreLab = incoreLab;
     }
 
     public List<Integer> getService() {
@@ -122,4 +105,6 @@ public class UserUsages {
     public void setService(List<Integer> service){
         this.service = service;
     }
+
+
 }

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/UserUsages.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/models/UserUsages.java
@@ -26,10 +26,6 @@ public class UserUsages {
     public int dfr3;
     public long datasetSize;
     public long hazardDatasetSize;
-//    "cpu": [ 4, 16 ],
-//         "mem": [ 8, 32 ],
-//         "disk": 512,
-//         "service": [ 200, 5 ]
     public List<Integer> cpu;
     public List<Integer> mem;
     public int disk;

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/JsonUtils.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/JsonUtils.java
@@ -173,8 +173,8 @@ public class JsonUtils {
         outJson.put("total_file_size_of_datasets_byte", dataset_file_size);
         outJson.put("total_file_size_of_hazard_datasets", out_hazard_size);
         outJson.put("total_file_size_of_hazard_datasets_byte", usage.getHazardDatasetSize());
-        outJson.put("service", usage.getService());
-        outJson.put("incoreLab", usage.getIncoreLab().toJson());
+        if (usage.getService() != null) outJson.put("service", usage.getService());
+        if (usage.getIncoreLab() != null) outJson.put("incoreLab", usage.getIncoreLab().toJson());
 
         return outJson;
     }

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/JsonUtils.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/JsonUtils.java
@@ -173,6 +173,10 @@ public class JsonUtils {
         outJson.put("total_file_size_of_datasets_byte", dataset_file_size);
         outJson.put("total_file_size_of_hazard_datasets", out_hazard_size);
         outJson.put("total_file_size_of_hazard_datasets_byte", usage.getHazardDatasetSize());
+        outJson.put("incore_lab_cpu", usage.getCpu());
+        outJson.put("incore_lab_memory", usage.getMem());
+        outJson.put("incore_lab_disk_size", usage.getDisk());
+        outJson.put("incore_lab_service", usage.getService());
 
         return outJson;
     }

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/JsonUtils.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/JsonUtils.java
@@ -173,10 +173,8 @@ public class JsonUtils {
         outJson.put("total_file_size_of_datasets_byte", dataset_file_size);
         outJson.put("total_file_size_of_hazard_datasets", out_hazard_size);
         outJson.put("total_file_size_of_hazard_datasets_byte", usage.getHazardDatasetSize());
-        outJson.put("cpu", usage.getCpu());
-        outJson.put("mem", usage.getMem());
-        outJson.put("disk", usage.getDisk());
         outJson.put("service", usage.getService());
+        outJson.put("incoreLab", usage.getIncoreLab().toJson());
 
         return outJson;
     }

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/JsonUtils.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/JsonUtils.java
@@ -173,10 +173,10 @@ public class JsonUtils {
         outJson.put("total_file_size_of_datasets_byte", dataset_file_size);
         outJson.put("total_file_size_of_hazard_datasets", out_hazard_size);
         outJson.put("total_file_size_of_hazard_datasets_byte", usage.getHazardDatasetSize());
-        outJson.put("incore_lab_cpu", usage.getCpu());
-        outJson.put("incore_lab_memory", usage.getMem());
-        outJson.put("incore_lab_disk_size", usage.getDisk());
-        outJson.put("incore_lab_service", usage.getService());
+        outJson.put("cpu", usage.getCpu());
+        outJson.put("mem", usage.getMem());
+        outJson.put("disk", usage.getDisk());
+        outJson.put("service", usage.getService());
 
         return outJson;
     }

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/JsonUtils.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/JsonUtils.java
@@ -158,7 +158,7 @@ public class JsonUtils {
         } else {
             out_hazard_size = hazard_size_kb + " KB";
         }
-
+//        TODO why reconstruct? can't we use default model and let jackson to serialize and deserialize?
         JSONObject outJson = new JSONObject();
         if (isGroup) {
             outJson.put("group", username);


### PR DESCRIPTION
I updated the incore-dev space collection and views to include the logic of computing the final incore-lab quota. 
The return object should now include same incore lab quotas
```
{
    "cpu": [
        4,
        16
    ],
    "disk": 512,
    "mem": [
        8,
        32
    ],
    "service": [
        200,
        5
    ],
    ...
    "user": "cwang138"
}
```
To test:
- Point mongo environment to incore-dev
e.g. SPACE_MONGODB_URI=mongodb://root:{password}@localhost:27019/spacedb?connectTimeoutMS\=10000&authSource\=admin&authMechanism\=SCRAM-SHA-256

- Kubectl forward
- FarmRun and GET (with x-auth-userinfo and x-auth-usergroup set) 
http://localhost:8080/space/api/allocations/
http://localhost:8080/space/api/allocations/users/cwang138
http://localhost:8080/space/api/allocations/users/{your_username}

[UserFinalQuota.js.zip](https://github.com/IN-CORE/incore-services/files/12731510/UserFinalQuota.js.zip)

p.s. mongoview script here --> 