### PR TITLE
205 add geopackage handling in incore services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Geopakage handling in services  [#205](https://github.com/IN-CORE/incore-services/issues/205)
+
 ### Changed
 - Geoserver connection library has been removed and new connection object has been added [#190](https://github.com/IN-CORE/incore-services/issues/190)
 
@@ -17,8 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Refactor POST /types API [#159](https://github.com/IN-CORE/incore-services/issues/159)
 - Refactor GET /types endpoint [#156](https://github.com/IN-CORE/incore-services/issues/156)
 - Refactor DELETE /types/{id} endpoint [#160](https://github.com/IN-CORE/incore-services/issues/160)
-- Added filtering by space in GET /types endpoint [191](https://github.com/IN-CORE/incore-services/issues/191)
-- Added limiting and offset for GET /types/search endpoint and to GET /types endpoint [#195](https://github.com/IN-CORE/incore-services/issues/195)
+- Filtering by space in GET /types endpoint [191](https://github.com/IN-CORE/incore-services/issues/191)
+- Limiting and offset for GET /types/search endpoint and to GET /types endpoint [#195](https://github.com/IN-CORE/incore-services/issues/195)
 
 ### Changed
 - Refactor AllocationsController and UsageController to use updated authorizer [#143](https://github.com/IN-CORE/incore-services/issues/143)

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -60,11 +60,11 @@ apply plugin: 'org.gretty'
 //a "farm" is the gretty term for multiple webapps that can be run
 //in the same webapp service.
 farm {
-//    webapp ':dfr3-service'
+    webapp ':dfr3-service'
     webapp ':data-service'
-//    webapp ':hazard-service'
-//    webapp ':semantics-service'
-//    webapp ':space-service'
+    webapp ':hazard-service'
+    webapp ':semantics-service'
+    webapp ':space-service'
 }
 
 task farmWars(dependsOn: war, type: Copy) {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -60,11 +60,11 @@ apply plugin: 'org.gretty'
 //a "farm" is the gretty term for multiple webapps that can be run
 //in the same webapp service.
 farm {
-    webapp ':dfr3-service'
+//    webapp ':dfr3-service'
     webapp ':data-service'
-    webapp ':hazard-service'
-    webapp ':semantics-service'
-    webapp ':space-service'
+//    webapp ':hazard-service'
+//    webapp ':semantics-service'
+//    webapp ':space-service'
 }
 
 task farmWars(dependsOn: war, type: Copy) {

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
@@ -893,11 +893,12 @@ public class DatasetController {
             }
             File tmpFile = new File(FilenameUtils.concat(DATA_REPO_FOLDER, dataFDs.get(0).getDataURL()));
 
-            // check if geopackage only has a single layer
+            // check if geopackage only has a single layer and the layer name is the same as file name
             if (!GeotoolsUtils.isGpkgSingleLayer(tmpFile)) {
                 FileUtils.removeFilesFromFileDescriptor(dataset.getFileDescriptors());
-                logger.debug("The geopackage has to have a single layer.");
-                throw new IncoreHTTPException(Response.Status.NOT_ACCEPTABLE, "Geopackage is not a single layer.");
+                logger.debug("The geopackage has to have a single layer, and layer name should be the same as file name.");
+                throw new IncoreHTTPException(Response.Status.NOT_ACCEPTABLE,
+                    "Geopackage is not a single layer or layer name is not the same as file name.");
             }
 
             // check if geopackage has guid
@@ -954,12 +955,10 @@ public class DatasetController {
                         repository.addDataset(dataset);
                         // uploading geoserver must involve the process of renaming the database in geopackage
                         File gpkgFile = new File(FilenameUtils.concat(DATA_REPO_FOLDER, dataFDs.get(0).getDataURL()));
-                        File renamedFile = FileUtils.generateRenameGpkgDbName(gpkgFile, datasetId);
-                        if (!GeoserverUtils.uploadGpkgToGeoserver(dataset.getId(), renamedFile)) {
+                        if (!GeoserverUtils.uploadGpkgToGeoserver(dataset.getId(), gpkgFile)) {
                             logger.error("Fail to upload geopackage file");
                             throw new IncoreHTTPException(Response.Status.INTERNAL_SERVER_ERROR, "Fail to upload geopakcage file.");
                         }
-                        FileUtils.deleteTmpDir(renamedFile);
                     } else {
                         if (isShp && isPrj) {
                             GeoserverUtils.datasetUploadToGeoserver(dataset, repository, isShp, isTif, isAsc);

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
@@ -886,6 +886,11 @@ public class DatasetController {
 
         SimpleFeatureCollection sfc = null; // this will be used for uploading geopackage to geoserver
         if (format.equalsIgnoreCase(FileUtils.FORMAT_GEOPACKAGE)) {
+            if (!isGpkg) {
+                FileUtils.removeFilesFromFileDescriptor(dataset.getFileDescriptors());
+                logger.debug("The given file is not a geopackage file.");
+                throw new IncoreHTTPException(Response.Status.NOT_ACCEPTABLE, "Give file is not a geopackage file.");
+            }
             File tmpFile = new File(FilenameUtils.concat(DATA_REPO_FOLDER, dataFDs.get(0).getDataURL()));
 
             // check if geopackage only has a single layer

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
@@ -942,11 +942,14 @@ public class DatasetController {
                         repository.addDataset(dataset);
                         // uploading geoserver must involve the process of renaming the database in geopackage
                         File gpkgFile = new File(FilenameUtils.concat(DATA_REPO_FOLDER, dataFDs.get(0).getDataURL()));
-                        File renamedFile = FileUtils.renameGeopackageDbName(gpkgFile, datasetId);
+                        // create temp directory
+                        String tempGpkgDir = Files.createTempDirectory(FileUtils.DATA_TEMP_DIR_PREFIX).toString();
+                        File renamedFile = FileUtils.renameGeopackageDbName(gpkgFile, datasetId, tempGpkgDir);
                         if (!GeoserverUtils.uploadGpkgToGeoserver(dataset.getId(), renamedFile)) {
                             logger.error("Fail to upload geopackage file");
                             throw new IncoreHTTPException(Response.Status.INTERNAL_SERVER_ERROR, "Fail to upload geopakcage file.");
                         }
+                        FileUtils.deleteTmpDir(renamedFile);
                     } else {
                         if (isShp && isPrj) {
                             GeoserverUtils.datasetUploadToGeoserver(dataset, repository, isShp, isTif, isAsc);

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/FileUtils.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/FileUtils.java
@@ -892,7 +892,15 @@ public class FileUtils {
         }
     }
 
-    public static File renameGeopackageDbName(File inFile, String store, String tempDir) throws IOException {
+    /**
+     * create a temporary geopackage file with the layer's name with dataset it
+     *
+     * @param inFile
+     * @param store
+     * @return
+     * @throws IOException
+     */
+    public static File generateRenameGpkgDbName(File inFile, String store) throws IOException {
         File renamedGpkgFile = null;
 
         try {
@@ -907,11 +915,14 @@ public class FileUtils {
             // get all layer names in input geopackage file
             String[] layerNames = dataStore.getTypeNames();
 
-            renamedGpkgFile = new File(tempDir + File.separator + store + ".gpkg");
-
+            // input geopackage should only have a single layer
             if (layerNames.length == 1) {
-                // input geopackage should only have a single layer
                 String oldLayerName = layerNames[0];
+
+                // create temp directory
+                String tempDir = Files.createTempDirectory(FileUtils.DATA_TEMP_DIR_PREFIX).toString();
+
+                renamedGpkgFile = new File(tempDir + File.separator + store + ".gpkg");
 
                 // get input geopackage layer
                 SimpleFeatureStore oldFeatureStore = (SimpleFeatureStore) dataStore.getFeatureSource(oldLayerName);
@@ -945,76 +956,5 @@ public class FileUtils {
         }
 
         return renamedGpkgFile;
-//        String currentTableName = "old_table_name"; // Replace with the current table name
-//        String newTableName = "new_table_name"; // Replace with the desired new table name
-//
-//        // SQLite JDBC URL
-//        String jdbcUrl = "jdbc:sqlite:" + tmpFile.getAbsolutePath();
-//
-//        try {
-//            // Create a connection to the GeoPackage using SQLite JDBC
-//            Connection connection = DriverManager.getConnection(jdbcUrl);
-//
-//            // Create a statement
-//            Statement statement = connection.createStatement();
-//
-//            // Rename the table
-//            String sql = "ALTER TABLE " + currentTableName + " RENAME TO " + newTableName;
-//            statement.executeUpdate(sql);
-//
-//            // Close the statement and connection
-//            statement.close();
-//            connection.close();
-//
-//            System.out.println("Table renamed successfully.");
-//        } catch (Exception e) {
-//            e.printStackTrace();
-//        }
-//        String tempDir = Files.createTempDirectory(FileUtils.DATA_TEMP_DIR_PREFIX).toString();
-//        List<File> infiles = new ArrayList<>();
-//        infiles.add(inFile);
-//
-//        List<File> copiedFileList = GeotoolsUtils.performCopyFiles(infiles, tempDir, "", false, "shp");
-//        // Define GeoPackage file path
-//        String geoPackageFilePath = copiedFileList.get(0).getAbsolutePath();
-//
-//        // SQLite JDBC URL
-//        String jdbcUrl = "jdbc:sqlite:" + geoPackageFilePath;
-//
-//        try {
-//            // Create a connection to the GeoPackage using SQLite JDBC
-//            Connection connection = DriverManager.getConnection(jdbcUrl);
-//
-//            // Get database metadata
-//            DatabaseMetaData metaData = connection.getMetaData();
-//
-//            // List all tables in the GeoPackage
-//            ResultSet tables = metaData.getTables(null, null, null, new String[]{"TABLE"});
-//
-//            // Iterate through the table names
-//            while (tables.next()) {
-//                String tableName = tables.getString("TABLE_NAME");
-//                System.out.println("Found table: " + tableName);
-//
-//                // Replace this condition with your logic to identify the table you want to rename
-//                if (tableName.equals("guid_test")) {
-//                    String newTableName = store; // Replace with the desired new table name
-//
-//                    // Rename the table
-//                    String sql = "ALTER TABLE " + tableName + " RENAME TO " + newTableName;
-//                    connection.createStatement().executeUpdate(sql);
-//
-//                    System.out.println("Table renamed successfully.");
-//                    break; // Exit the loop once the desired table is found and renamed
-//                }
-//            }
-//
-//            // Close the connection
-//            connection.close();
-//        } catch (Exception e) {
-//            e.printStackTrace();
-//        }
-//
-//        return copiedFileList.get(0);
     }
 }

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/FileUtils.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/FileUtils.java
@@ -42,11 +42,7 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.Statement;
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
+
 
 /**
  * Created by ywkim on 6/8/2017.

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverRestApi.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverRestApi.java
@@ -204,8 +204,9 @@ public class GeoserverRestApi {
             String restUrl = this.geoserverUrl + "/rest/workspaces/" + GEOSERVER_WORKSPACE + "/datastores/" + store + "/file.shp";
             published = this.postFileToGeoserver(restUrl, inFile, "zip");
         } else if (inExt.equalsIgnoreCase("gpkg")) {
-            String restUrl = this.geoserverUrl + "/rest/workspaces/" + GEOSERVER_WORKSPACE + "/datastores/" + store + "/file.gpkg";
-            published = this.postFileToGeoserver(restUrl, inFile, "tif");
+            String restUrl = this.geoserverUrl + "/rest/workspaces/" + GEOSERVER_WORKSPACE + "/datastores/" + store +
+                "/file.gpkg?configure=all&name=" + store;
+            published = this.postFileToGeoserver(restUrl, inFile, "gpkg");
         } else if (inExt.equalsIgnoreCase("tif")) {
             String restUrl = this.geoserverUrl + "/rest/workspaces/" + GEOSERVER_WORKSPACE + "/coveragestores/" + store + "/file.geotiff";
             published = this.postFileToGeoserver(restUrl, inFile, "tif");

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverRestApi.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverRestApi.java
@@ -12,6 +12,9 @@ import java.io.FileInputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 
 public class GeoserverRestApi {
     public static final String DEFAULT_CRS = "EPSG:4326";
@@ -132,6 +135,192 @@ public class GeoserverRestApi {
     }
 
     /**
+     * upload file to geoserver
+     *
+     * @param store
+     * @param inFile
+     * @param inExt
+     * @return
+     */
+    public boolean uploadToGeoserver(String store, File inFile, String inExt) {
+        String fileName = FilenameUtils.getBaseName(inFile.getName());
+
+        // check if workspace exists
+        boolean created = createWorkspace(this.geoserverUrl, GEOSERVER_WORKSPACE);
+        boolean published = false;
+
+        if (inExt.equalsIgnoreCase("shp")) {
+            String restUrl = this.geoserverUrl + "/rest/workspaces/" + GEOSERVER_WORKSPACE + "/datastores/" + store + "/file.shp";
+            published = this.postFileToGeoserver(restUrl, inFile, "zip");
+        } else if (inExt.equalsIgnoreCase("gpkg")) {
+            // geopackage should have different steps due to its renaming convention in IN-CORE
+            // since IN-CORE uses the dataset id as a file name in geoserver, the geopackage name needs to be renamed to dataset id
+            // to rename, the POST action should create datastore first with the geopackage data,
+            // then create layer with xml to control the name to be changed to dataset id.
+            // if you don't need to rename, set renameData boolean in following line to false
+            Boolean renameData = true;
+            if (renameData) {
+                // create datastore then create layer
+                try {
+                    String restUrl = this.geoserverUrl + "/rest";
+                    String fileNameNoExt = fileName.split("\\.")[0];
+                    int datastoreResponse = createDatastore(restUrl, GEOSERVER_WORKSPACE, store, inFile.getAbsolutePath(), "geopackage");
+                    int layerResponse = createLayer(restUrl, GEOSERVER_WORKSPACE, store, store, fileNameNoExt);
+                    if (datastoreResponse == 201 && layerResponse == 201) {
+                        published = true;
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            } else{
+                String restUrl = this.geoserverUrl + "/rest/workspaces/" + GEOSERVER_WORKSPACE + "/datastores/" + store +
+                    "/file.gpkg?configure=all&name=" + store;
+                published = this.postFileToGeoserver(restUrl, inFile, "gpkg");
+            }
+        } else if (inExt.equalsIgnoreCase("tif")) {
+            String restUrl = this.geoserverUrl + "/rest/workspaces/" + GEOSERVER_WORKSPACE + "/coveragestores/" + store + "/file.geotiff";
+            published = this.postFileToGeoserver(restUrl, inFile, "tif");
+        }
+
+        return published;
+    }
+
+    /**
+     *  XML template for feature
+     *
+     */
+    public final String LAYER_XML_TEMPLATE = "<featureType>\n" +
+        "  <name>{ft_name}</name>\n" +
+        "  <title>{ft_title}</title>\n" +
+        "  <nativeName>{ft_native_name}</nativeName>\n" +
+        "</featureType>";
+
+    /**
+     * create workspace
+     *
+     * @param geoserverUrl
+     * @param workspace
+     * @return
+     */
+    public boolean createWorkspace(String geoserverUrl, String workspace) {
+        final String restUrl = geoserverUrl + "/rest/workspaces";
+        final String wsXml = "<workspace><name>" + workspace + "</name></workspace>";
+        final String result = postXmlToGeoserver(restUrl, wsXml, "xml");
+
+        return result != null;
+    }
+
+    /**
+     * Create datastore in geoserver
+     *
+     * @param baseUrl
+     * @param workspaceName
+     * @param datastoreName
+     * @param fileName
+     * @param fileFormat
+     * @throws IOException
+     */
+    public int createDatastore(String baseUrl, String workspaceName, String datastoreName,
+                                        String fileName, String fileFormat) throws IOException {
+        String formatUrl = "/file.shp";
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", "application/zip");
+
+        if ("shapefile".equals(fileFormat)) {
+            formatUrl = "/file.shp";
+            headers.put("Content-Type", "application/zip");
+        } else if ("geopackage".equals(fileFormat)) {
+            formatUrl = "/file.gpkg";
+            headers.put("Content-Type", "application/x-sqlite3");
+        }
+
+        String datastoreUrl = baseUrl + "/workspaces/" + workspaceName + "/datastores/"
+            + datastoreName + formatUrl;
+
+        Map<String, String> params = new HashMap<>();
+        params.put("configure", "none");
+        params.put("update", "overwrite");
+
+        try (FileInputStream fileInputStream = new FileInputStream(new File(fileName))) {
+            byte[] fileData = fileInputStream.readAllBytes();
+            return sendHttpRequest(datastoreUrl, headers, fileData, params, "PUT");
+        }
+    }
+
+    /**
+     * Create layer after datastore created, this should be performed after createDatastore
+     *
+     * @param baseUrl
+     * @param workspaceName
+     * @param datastoreName
+     * @param layerName
+     * @param nativeName
+     * @throws IOException
+     */
+    public int createLayer(String baseUrl, String workspaceName, String datastoreName,
+                                    String layerName, String nativeName) throws IOException {
+        String layerUrl = baseUrl + "/workspaces/" + workspaceName + "/datastores/" + datastoreName + "/featuretypes";
+        String layerXml = LAYER_XML_TEMPLATE.replace("{ft_name}", layerName)
+            .replace("{ft_title}", layerName)
+            .replace("{ft_native_name}", nativeName);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", "text/xml");
+
+        int responseCode = sendHttpRequest(layerUrl, headers, layerXml.getBytes(), null, "POST");
+
+        return responseCode;
+    }
+
+    /**
+     * Send http request to geoserver
+     *
+     * @param url
+     * @param headers
+     * @param data
+     * @param params
+     * @param method
+     * @throws IOException
+     */
+    public int sendHttpRequest(String url, Map<String, String> headers, byte[] data,
+                                        Map<String, String> params, String method) throws IOException {
+        HttpURLConnection connection = createHttpConnection(url, method, headers);
+
+        if (params != null && !params.isEmpty()) {
+            url += getQueryString(params);
+        }
+
+        try (OutputStream outputStream = connection.getOutputStream()) {
+            outputStream.write(data);
+        }
+
+        int responseCode = connection.getResponseCode();
+
+        return responseCode;
+    }
+
+    public HttpURLConnection createHttpConnection(String apiUrl, String method, Map<String, String> headers)
+        throws IOException {
+        URL url = new URL(apiUrl);
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+
+        // Set authentication and headers
+        String credentials = GEOSERVER_USER + ":" + GEOSERVER_PW;
+        String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+        connection.setRequestProperty("Authorization", "Basic " + encodedCredentials);
+
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            connection.setRequestProperty(entry.getKey(), entry.getValue());
+        }
+
+        // Set request method and content type
+        connection.setRequestMethod(method);
+        connection.setDoOutput(true);
+
+        return connection;
+    }
+
+    /**
      * create http connection to geoserver rest api
      *
      * @param apiUrl
@@ -145,7 +334,7 @@ public class GeoserverRestApi {
 
         // create connection with authentication and post request
         String credentials = GEOSERVER_USER + ":" + GEOSERVER_PW;
-        String encodedCredentials = java.util.Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+        String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
         connection.setRequestProperty("Authorization", "Basic " + encodedCredentials);
         if (contType.equalsIgnoreCase("xml")) {
             connection.setRequestMethod("POST");
@@ -171,48 +360,22 @@ public class GeoserverRestApi {
     }
 
     /**
-     * create workspace
+     * Create query string for geoserver rest endpoint
      *
-     * @param geoserverUrl
-     * @param workspace
+     * @param params
      * @return
      */
-    public boolean createWorkspace(String geoserverUrl, String workspace) {
-        final String restUrl = geoserverUrl + "/rest/workspaces";
-        final String wsXml = "<workspace><name>" + workspace + "</name></workspace>";
-        final String result = postXmlToGeoserver(restUrl, wsXml, "xml");
-
-        return result != null;
-    }
-
-    /**
-     * upload file to geoserver
-     *
-     * @param store
-     * @param inFile
-     * @param inExt
-     * @return
-     */
-    public boolean uploadToGeoserver(String store, File inFile, String inExt) {
-        String fileName = FilenameUtils.getBaseName(inFile.getName());
-
-        // check if workspace exists
-        boolean created = createWorkspace(this.geoserverUrl, GEOSERVER_WORKSPACE);
-        boolean published = false;
-
-        if (inExt.equalsIgnoreCase("shp")) {
-            String restUrl = this.geoserverUrl + "/rest/workspaces/" + GEOSERVER_WORKSPACE + "/datastores/" + store + "/file.shp";
-            published = this.postFileToGeoserver(restUrl, inFile, "zip");
-        } else if (inExt.equalsIgnoreCase("gpkg")) {
-            String restUrl = this.geoserverUrl + "/rest/workspaces/" + GEOSERVER_WORKSPACE + "/datastores/" + store +
-                "/file.gpkg?configure=all&name=" + store;
-            published = this.postFileToGeoserver(restUrl, inFile, "gpkg");
-        } else if (inExt.equalsIgnoreCase("tif")) {
-            String restUrl = this.geoserverUrl + "/rest/workspaces/" + GEOSERVER_WORKSPACE + "/coveragestores/" + store + "/file.geotiff";
-            published = this.postFileToGeoserver(restUrl, inFile, "tif");
+    public String getQueryString(Map<String, String> params) {
+        StringBuilder queryString = new StringBuilder();
+        queryString.append("?");
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            queryString.append(entry.getKey())
+                .append("=")
+                .append(entry.getValue())
+                .append("&");
         }
-
-        return published;
+        queryString.deleteCharAt(queryString.length() - 1); // Remove the trailing "&"
+        return queryString.toString();
     }
 
     /** delete store from geoserver

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeotoolsUtils.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeotoolsUtils.java
@@ -968,6 +968,13 @@ public class GeotoolsUtils {
         return isGuid;
     }
 
+    /**
+     * check if geopackage has single layer and layer name is the same as the file name
+     *
+     * @param inFile
+     * @return
+     * @throws IOException
+     */
     public static boolean isGpkgSingleLayer(File inFile) throws IOException {
         Boolean output = false;
         try {
@@ -983,7 +990,12 @@ public class GeotoolsUtils {
             String[] layerNames = dataStore.getTypeNames();
 
             if (layerNames.length == 1) {
-                output = true;
+                // check if the layername is the same as file name
+                String layerName = layerNames[0];
+                String fileName = inFile.getName().split("\\.")[0];
+                if (layerName.equals(fileName)) {
+                    output = true;
+                }
             }
         } catch (IOException e) {
             throw new IOException("Unable to open geopackage file.");

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeotoolsUtils.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeotoolsUtils.java
@@ -967,5 +967,29 @@ public class GeotoolsUtils {
 
         return isGuid;
     }
+
+    public static boolean isGpkgSingleLayer(File inFile) throws IOException {
+        Boolean output = false;
+        try {
+            HashMap<String, Object> map = new HashMap<>();
+            map.put(GeoPkgDataStoreFactory.DBTYPE.key, "geopkg");
+            map.put(GeoPkgDataStoreFactory.DATABASE.key, inFile.getAbsoluteFile());
+            DataStore dataStore = DataStoreFinder.getDataStore(map);
+            if (dataStore == null) {
+                throw new IOException("Unable to open geopackage file");
+            }
+
+            // get all layer names in input geopackage file
+            String[] layerNames = dataStore.getTypeNames();
+
+            if (layerNames.length == 1) {
+                output = true;
+            }
+        } catch (IOException e) {
+            throw new IOException("Unable to open geopackage file.");
+        }
+
+        return output;
+    }
 }
 


### PR DESCRIPTION
This PR has the followings

-  service recognizes the geopackage file
-  dataset's format should be "geopackage"
-  check if geopackage has guid 
-  check if geopackage has only one layer
- check if geopackage's data table name is the same as geopackage file name (this is necessary for posting it to geoserver)
-  geoserver should be able to handle geoserver upload
-  when uploading geoserver, it has to have dataset id as a name instead of database name

**Here's how to test**

- Before the test, please download guid_yes.zip and geopackages.zip file that are attached in the next comment
- You don't need to unzip guid_yes.zip but need to unzip geopackages.zip file since the github attachment doesn't allow to attach gpkg files.

**Scenario 1 (should make an error) - upload shapefile to geopackage dataset**
1. create a new dataset using the json 
  {"format": "geopackage", "title": "test-delete", "description": "delete me", "dataType": "incore:addressPoints"}
2. using the dataset created above, attach the guid_yes.zip file (shpaefile) from the attachment
3. this should give the error saying the given file is not a geopackage file
4. this should be the same if you upload unzipped shapefile if you test uploading after unzip the zip file
5. after finishing the test, please remove the dataset created in step 1

**Scenario 2 (should make an error) - upload geopackage file to shapefile dataset**
1. create a new dataset using the json
  {"format": "shapefile", "title": "test-delete", "description": "delete me", "dataType": "incore:addressPoints"}
2. using the dataset created above, attach the 'guid_test.gpkg' file from the attachment
3. this should give the error saying the format and file doesn't match
4. after finishing the test, please remove the dataset created in step 1

**Scenario 3 (should make an error) - upload geopakcage file that has no guid field**
1. create a new dataset using the json
  {"format": "geopackage", "title": "test-delete", "description": "delete me", "dataType": "incore:addressPoints"}
2. using the dataset created above, attach the 'guid_no.gpkg' file from the attachment
3. this should give the error saying there is no guid field
4. do not delete the dataset created in step 1 since it will be used in the next scenario

**Scenario 4 (should make an error) - upload geopackage file that has multiple layers in a single file**
1. use the dataset that was created in Scenario 3
2. using the dataset, attach the 'epn_network.gpkg' file from the attachment
3. this should give the error saying the data is not a single layer
4. do not delete the dataset create in Scenario 3 yet since it will be used in the next scenario as well

**Scenario 5 (working scenario) - upload geopackage file with guid and single layer**
1. use the dataset that was created in Scenario 3
2. using the dataset, attach the 'guid_test.gpkg' file from the attachment
3. this should work without any error
4. the updated dataset has one entry in the fileDescriptor
5. the updated dataset should have bounding box values
6. please try to see the preview in the data viewer 
  - this will show only guid_test.gpkg but geoserver should have the dataset with correct id
  - the frontend should be updated to show the geopakcage as well
  - you can check the dev geoserver with dataset id to see if the dataset is there (optional)
  - if you see the dataset, the renaming and uploading the geoserver is successful (optional)
7. please delete the dataset created in the test