### PR TITLE
Allow semantics to be added to space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Owner item added to the dataset, hazard, and dfr3 object [#92](https://github.com/IN-CORE/incore-services/issues/92)
 - Attenuation model Sadigh et al. 1997 [#208](https://github.com/IN-CORE/incore-services/issues/208)
 - Include incore lab quota to the allocation endpoints [#217](https://github.com/IN-CORE/incore-services/issues/217)
+- Allow semantics id to be added to space member [#229](https://github.com/IN-CORE/incore-services/issues/229)
 
 ### Changed
 - Geoserver connection library has been removed and new connection object has been added [#190](https://github.com/IN-CORE/incore-services/issues/190)

--- a/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/controllers/SpaceController.java
+++ b/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/controllers/SpaceController.java
@@ -32,6 +32,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.apache.log4j.Logger;
 import org.glassfish.jersey.media.multipart.FormDataParam;
+import org.json.JSONObject;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -96,6 +97,7 @@ public class SpaceController {
     private static final String DATA_SERVICE_URL = System.getenv("DATA_SERVICE_URL");
     private static final String HAZARD_SERVICE_URL = System.getenv("HAZARD_SERVICE_URL");
     private static final String DFR3_SERVICE_URL = System.getenv("DFR3_SERVICE_URL");
+    private static final String SEMANTICS_SERVICE_URL = System.getenv("SEMANTICS_SERVICE_URL");
     private static final String EARTHQUAKE_URL = HAZARD_SERVICE_URL + "/hazard/api/earthquakes/";
     private static final String TORNADO_URL = HAZARD_SERVICE_URL + "/hazard/api/tornadoes/";
     private static final String HURRICANE_WF_URL = HAZARD_SERVICE_URL + "/hazard/api/hurricaneWindfields/";
@@ -106,6 +108,7 @@ public class SpaceController {
     private static final String REPAIR_URL = DFR3_SERVICE_URL + "/dfr3/api/repairs/";
     private static final String RESTORATION_URL = DFR3_SERVICE_URL + "/dfr3/api/restorations/";
     private static final String MAPPING_URL = DFR3_SERVICE_URL + "/dfr3/api/mappings/";
+    private static final String SEMANTICS_URL = SEMANTICS_SERVICE_URL + "/semantics/api/types/";
     private static final String DATA_URL = DATA_SERVICE_URL + "/data/api/datasets/";
 
     private static final String SPACE_MEMBERS = "members";
@@ -555,6 +558,16 @@ public class SpaceController {
             isValidNonHazardMember = true;
         } else if (get(MAPPING_URL, memberId, username, userGroups) != null) {
             isValidNonHazardMember = true;
+        } else if (get(SEMANTICS_URL, memberId, username, userGroups) != null) {
+            // TODO semantics endpoint accept name instead of id; need to trade for name
+            String jsonResponse = get(SEMANTICS_URL, memberId, username, userGroups);
+            JSONObject jsonObject = new JSONObject(jsonResponse);
+            if (jsonObject.has("id")) {
+                memberId = jsonObject.getString("id");
+                isValidNonHazardMember = true;
+            } else {
+                System.out.println("No 'id' field found in the JSON.");
+            }
         }
 
         if (isValidNonHazardMember) {

--- a/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/controllers/SpaceController.java
+++ b/server/space-service/src/main/java/edu/illinois/ncsa/incore/service/space/controllers/SpaceController.java
@@ -543,7 +543,7 @@ public class SpaceController {
 
         boolean isValidNonHazardMember = false;
 
-        // TODO semantics endpoint accept name instead of id; need to trade for name
+        // TODO semantics endpoint accept name instead of id; need to trade name for id
         if (get(SEMANTICS_URL, memberId, username, userGroups) != null) {
             String jsonResponse = get(SEMANTICS_URL, memberId, username, userGroups);
             JSONObject jsonObject = new JSONObject(jsonResponse);


### PR DESCRIPTION
I realize we didn't allow semantics id to be added to space via the member endpoint. Since semantics endpoint /types/{name} accepts name instead of member id, it makes the logic of validating before hand very difficult.

This is just a quick hack to workaround. We should prboably review this design and properly address it later.

------------
To test:
1. make sure you add SEMANTICS_SERVICE_URL=http://localhost:8080 in the environment variable
2. try POST `http://localhost:8080/space/api/spaces/5a284f09c7d30d13bc0819a3/members/ergo:buriedPipelineTopology`
