### PR TITLE
Fixes #234 Semantic services types endpoint missing access control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Semantic services types endpoint missing access control [#234](https://github.com/IN-CORE/incore-services/issues/234)
+
 ## [1.21.0] - 2023-10-11
 
 ### Added
@@ -44,7 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - Missing log4j.properties file required to configure logging [#148](https://github.com/IN-CORE/incore-services/issues/148)
-- Changed the endpoint /types/{name} response to Document [#193](https://github.com/IN-CORE/incore-services/pull/193)
+- Changed the endpoint /types/{name} response to Document [#193](https://github.com/IN-CORE/incore-services/issues/192)
 
 ## [1.14.0] - 2023-06-14
 ### Added

--- a/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/controllers/TypeController.java
+++ b/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/controllers/TypeController.java
@@ -129,17 +129,21 @@ public class TypeController {
                 .collect(Collectors.toList());
         }
 
+        Set<String> userMembersSet = authorizer.getAllMembersUserHasReadAccessTo(username, spaceRepository.getAllSpaces(), groups);
+        List<Document> accessibleTypeList = typeList.stream().filter(type -> userMembersSet.contains(type.get("id"))).skip(offset)
+            .limit(limit).collect(Collectors.toList());
+
         if (detail) {
             return Response.ok(
-                typeList.stream()
-                    .skip(offset)
-                    .limit(limit)
-                    .collect(Collectors.toList()))
+                    accessibleTypeList.stream()
+                        .skip(offset)
+                        .limit(limit)
+                        .collect(Collectors.toList()))
                 .status(200)
                 .build();
         }
 
-        List<String> results = typeList.stream()
+        List<String> results = accessibleTypeList.stream()
             .map(t -> t.get("dc:title").toString())
             .sorted(comparator)
             .skip(offset)
@@ -234,7 +238,7 @@ public class TypeController {
             JSONArray columnsArray = tableSchema.getJSONArray("columns");
 
             // Loop through each column
-            List<Column> columns = new ArrayList<Column>();;
+            List<Column> columns = new ArrayList<Column>();
             for (int i = 0; i < columnsArray.length(); i++) {
                 JSONObject column = columnsArray.getJSONObject(i);
                 String columnName = column.getString("name");


### PR DESCRIPTION
Added missing access control to the GET all types endpoint. I didn't see any other endpoints missing access control. Some have it buried within another method call. 