### PR TITLE
Add sorting and validation on Type tableSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed 
 - Use Java models to represent semantics [#239](https://github.com/IN-CORE/incore-services/issues/239)
+- Sort Semantic Definition Alphabetically [#238](https://github.com/IN-CORE/incore-services/issues/238)
 
 ## [1.23.0] - 2023-12-13
 

--- a/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/model/Columns.java
+++ b/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/model/Columns.java
@@ -2,6 +2,8 @@ package edu.illinois.ncsa.incore.service.semantics.model;
 
 import dev.morphia.annotations.Embedded;
 import java.util.List;
+import java.util.stream.Collectors;
+import static edu.illinois.ncsa.incore.service.semantics.utils.CommonUtil.columnComparator;
 
 @Embedded()
 public class Columns {
@@ -16,5 +18,11 @@ public class Columns {
 
     public List<Column> getColumns() {
         return columns;
+    }
+
+    public List<Column> getSortedColumns(String sortBy, String order) {
+        return this.columns.stream()
+            .sorted(columnComparator(sortBy, order))
+            .collect(Collectors.toList());
     }
 }

--- a/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/model/Type.java
+++ b/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/model/Type.java
@@ -96,8 +96,7 @@ public class Type {
                     map.put("openvocab:versionnumber", this.getVersion());
 
                 } else if (field.getName().equals("tableSchema") && this.getTableSchema().getColumns() != null) {
-                    List<Map<String, Object>> updatedTableSchema = this.getTableSchema()
-                        .getSortedColumns("name", "asc").stream()
+                    List<Map<String, Object>> updatedTableSchema = this.getTableSchema().getColumns().stream()
                         .map(column -> column.constructOutput())
                         .collect(Collectors.toList());
                     Map<String, Object> columns = new HashMap<>();

--- a/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/model/Type.java
+++ b/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/model/Type.java
@@ -96,7 +96,8 @@ public class Type {
                     map.put("openvocab:versionnumber", this.getVersion());
 
                 } else if (field.getName().equals("tableSchema") && this.getTableSchema().getColumns() != null) {
-                    List<Map<String, Object>> updatedTableSchema = this.getTableSchema().getColumns().stream()
+                    List<Map<String, Object>> updatedTableSchema = this.getTableSchema()
+                        .getSortedColumns("name", "asc").stream()
                         .map(column -> column.constructOutput())
                         .collect(Collectors.toList());
                     Map<String, Object> columns = new HashMap<>();

--- a/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/utils/CommonUtil.java
+++ b/server/semantics-service/src/main/java/edu/illinois/ncsa/incore/service/semantics/utils/CommonUtil.java
@@ -1,5 +1,6 @@
 package edu.illinois.ncsa.incore.service.semantics.utils;
 
+import edu.illinois.ncsa.incore.service.semantics.model.Column;
 import edu.illinois.ncsa.incore.service.semantics.model.Type;
 import java.util.Comparator;
 
@@ -13,6 +14,20 @@ public class CommonUtil {
         else{
             // default to id
             comparator = Comparator.comparing(Type::getId);
+        }
+        if (order.equals("desc")) comparator = comparator.reversed();
+        return comparator;
+    }
+
+    public static Comparator<Column> columnComparator(String sortBy, String order){
+        // construct comparator
+        Comparator<Column> comparator;
+        if (sortBy.equals("title")) {
+            comparator = Comparator.comparing(Column::getTitles);
+        }
+        else{
+            // default to name
+            comparator = Comparator.comparing(Column::getName);
         }
         if (order.equals("desc")) comparator = comparator.reversed();
         return comparator;


### PR DESCRIPTION
This PR
- Added sorting ability to columns (removed after team discussion)
- Added POST type validation on columns

For testing, there are 2 endpoints need to look at:
- GET /semantics/api/types?detail=True
  - Within each tableSchema, columns should be sorted by name in ascending order
  - The following is an expected example
```
"tableSchema": {
            "columns": [
                {
                    "dc:description": "Probability of complete damage",
                    "datatype": "xsd:double",
                    "name": "complete",
                    "titles": "complete",
                    "qudt:unit": "qudt:CountingUnit",
                    "required": "true"
                },
                {
                    "dc:description": "Expected damage state",
                    "datatype": "xsd:string",
                    "name": "expectval",
                    "titles": "expectval",
                    "qudt:unit": "unit:UNITLESS",
                    "required": "true"
                }
            ]}
```

- POST /semantics/api/types
  - Please try uploading the following doc, and change the column titles ("dc:description", "datatype", "name", "titles", "qudt:unit", "required"). If any of the column titles is missing, the service is expected to throw an exception.
  - I added this validation because there are some invalid formats in semanticsdb, hence it might be good to add some constraints to avoid posting bad formats to the database. 
  - Remember to delete the type after testing if you are testing against dev/prod.
```
{"@context":
["http://www.w3.org/ns/csvw",
{"@language":"en","gml":"http://www.opengis.net/gml/","iwfs":"http://www.ionicsoft.com/wfs/","xlink":"http://www.w3.org/1999/xlink/","xsd":"http://www.w3.org/2001/XMLSchema/","qudt":"http://qudt.org/2.0/schema/qudt/","unit":"http://qudt.org/vocab/unit/","openvocab":"http://vocab.org/open/"}],
"dc:license":{"@id":"http://opendefinition.org/licenses/cc-by/"},"dc:title":"tests","dc:description":"","url":"tests","openvocab:versionnumber":"1.0",
"tableSchema":{"columns":[{"name":"","titles":"","dc:description":"","datatype":"xsd:integer","required":"true","qudt:unit":""}]}}
```
