### PR TITLE
Added raster geopackage checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- GeoPakage handling in services  [#205](https://github.com/IN-CORE/incore-services/issues/205)
+- Raster GeoPackage checker for not supporting it [#258](https://github.com/IN-CORE/incore-services/issues/258)
+
 ### Changed 
 - Use Java models to represent semantics [#239](https://github.com/IN-CORE/incore-services/issues/239)
 
@@ -24,7 +28,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [1.21.0] - 2023-10-11
 
 ### Added
-- Geopakage handling in services  [#205](https://github.com/IN-CORE/incore-services/issues/205)
 - Template dataset generation (CSV and Shapefile) API to semantics-service [#214](https://github.com/IN-CORE/incore-services/issues/214)
 - Owner item added to the dataset, hazard, and dfr3 object [#92](https://github.com/IN-CORE/incore-services/issues/92)
 - Attenuation model Sadigh et al. 1997 [#208](https://github.com/IN-CORE/incore-services/issues/208)

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
@@ -27,6 +27,7 @@ import edu.illinois.ncsa.incore.common.utils.UserGroupUtils;
 import edu.illinois.ncsa.incore.common.utils.UserInfoUtils;
 import edu.illinois.ncsa.incore.common.utils.AllocationUtils;
 import edu.illinois.ncsa.incore.common.AllocationConstants;
+import edu.illinois.ncsa.incore.common.utils.GeoUtils;
 import edu.illinois.ncsa.incore.service.data.dao.IRepository;
 import edu.illinois.ncsa.incore.service.data.models.Dataset;
 import edu.illinois.ncsa.incore.service.data.models.FileDescriptor;
@@ -896,18 +897,18 @@ public class DatasetController {
             // check if geopackage only has a single layer
             // and the layer name is the same as file name
             // and it is not the raster data since incore-service doesn't support it yet
-            int isGpkgFit = GeotoolsUtils.isGpkgFitToService(tmpFile);
-            if (isGpkgFit != 0) {
+            GeoUtils.gpkgValidationResult isGpkgFit = GeotoolsUtils.isGpkgFitToService(tmpFile);
+            if (isGpkgFit != GeoUtils.gpkgValidationResult.VALID) {
                 FileUtils.removeFilesFromFileDescriptor(dataset.getFileDescriptors());
-                if (isGpkgFit == 1) {
+                if (isGpkgFit == GeoUtils.gpkgValidationResult.RASTER_OR_NO_VECTOR_LAYER) {
                     logger.debug("The geopackage has not vector layer or contains the raster layer that is not being supported yet.");
                     throw new IncoreHTTPException(Response.Status.NOT_ACCEPTABLE,
                         "The geopackage has no vector layer or contains the raster layer that is not being supported yet.");
-                } else if (isGpkgFit == 2) {
+                } else if (isGpkgFit == GeoUtils.gpkgValidationResult.MULTIPLE_VECTOR_LAYERS) {
                     logger.debug("The geopackage has to have a single layer.");
                     throw new IncoreHTTPException(Response.Status.NOT_ACCEPTABLE,
                         "The geopackage has to have a single layer.");
-                } else if (isGpkgFit == 3) {
+                } else if (isGpkgFit == GeoUtils.gpkgValidationResult.NAME_MISMATCH) {
                     logger.debug("The geopackage's'layer name should be the same as file name.");
                     throw new IncoreHTTPException(Response.Status.NOT_ACCEPTABLE,
                         "The geopackage's'layer name should be the same as file name.");

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeotoolsUtils.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeotoolsUtils.java
@@ -978,10 +978,6 @@ public class GeotoolsUtils {
      *
      * @param inFile
      * @return
-     *          0: okay
-     *          1: data is raster or no vector layer
-     *          2: multiple vector layer
-     *          3: name not matching
      * @throws IOException
      */
     public static GeoUtils.gpkgValidationResult  isGpkgFitToService(File inFile) throws IOException {

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeotoolsUtils.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeotoolsUtils.java
@@ -12,6 +12,7 @@ package edu.illinois.ncsa.incore.service.data.utils;
 
 import com.opencsv.CSVReader;
 import edu.illinois.ncsa.incore.common.exceptions.IncoreHTTPException;
+import edu.illinois.ncsa.incore.common.utils.GeoUtils;
 import edu.illinois.ncsa.incore.service.data.models.Dataset;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.log4j.Logger;
@@ -983,7 +984,7 @@ public class GeotoolsUtils {
      *          3: name not matching
      * @throws IOException
      */
-    public static int isGpkgFitToService(File inFile) throws IOException {
+    public static GeoUtils.gpkgValidationResult  isGpkgFitToService(File inFile) throws IOException {
         int output = 0;
         try {
             HashMap<String, Object> map = new HashMap<>();
@@ -1005,18 +1006,18 @@ public class GeotoolsUtils {
                 String layerName = layerNames[0];
                 String fileName = inFile.getName().split("\\.")[0];
                 if (!layerName.equals(fileName)) {
-                     return 3;
+                     return GeoUtils.gpkgValidationResult.NAME_MISMATCH;
                 }
             } else if (layerNames.length == 0) {
-                return 1;
+                return GeoUtils.gpkgValidationResult.RASTER_OR_NO_VECTOR_LAYER;
             } else if (layerNames.length > 1) {
-                return 2;
+                return GeoUtils.gpkgValidationResult.MULTIPLE_VECTOR_LAYERS;
             }
         } catch (IOException e) {
             throw new IOException("Unable to open geopackage file.");
         }
 
-        return output;
+        return GeoUtils.gpkgValidationResult.VALID;
     }
 }
 

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/GeoUtils.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/GeoUtils.java
@@ -1,0 +1,2 @@
+package edu.illinois.ncsa.incore.common.utils;public class GeoUtils {
+}

--- a/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/GeoUtils.java
+++ b/server/incore-common/src/main/java/edu/illinois/ncsa/incore/common/utils/GeoUtils.java
@@ -1,2 +1,10 @@
-package edu.illinois.ncsa.incore.common.utils;public class GeoUtils {
+package edu.illinois.ncsa.incore.common.utils;
+
+public class GeoUtils {
+    public static enum gpkgValidationResult {
+        VALID,
+        RASTER_OR_NO_VECTOR_LAYER,
+        MULTIPLE_VECTOR_LAYERS,
+        NAME_MISMATCH
+    }
 }


### PR DESCRIPTION
This PR will check if the geopackage file contains raster layer or no vector date layer.
To test, please use attached geopackage file

Scenario1: Uploading the raster based geopackage file
1. download attached geopackages.zip file and unzip it. Should be two files, one named guid_test.gpkg, and the other is landcover.gpkg
2. create a dataset using the following json (the content doesn't matter too much because it is test. Only important one is the format, that should be geopackage)
{"format": "geopackage", "title": "test-delete", "description": "delete me", "dataType": "incore:addressPoints"}
3. attached the geopackage file to the dataset using the landcover.gpkg file (raster geopackage)
4. if you use landocver.gpkg, then you should see the error message saying, it doesn't contain any vector layer or it contains the raster
5. if you get error in step 3 above, try to attach the guid_test.gpkg (vector data). This should work without any error.
6. Remove the dataset you created in step 1.
[geopackages.zip](https://github.com/IN-CORE/incore-services/files/14029143/geopackages.zip)

