### PR TITLE
Make uploading to geoserver identical for both shapefile and geopackage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Add `hazardDatasets` field to TornadoDataset, TornadoModel and EarthquakeModel class [#213](https://github.com/IN-CORE/incore-services/issues/213)
+- Renaming option for uploading geoserver layers [#259](https://github.com/IN-CORE/incore-services/issues/259)
 
 ### Changed 
 - Use Java models to represent semantics [#239](https://github.com/IN-CORE/incore-services/issues/239)

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverRestApi.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverRestApi.java
@@ -138,7 +138,6 @@ public class GeoserverRestApi {
             return published;
         } catch (Exception e) {
             logger.error("Failed to POST to geoserver rest api", e);
-            System.out.println(e);
             return false;
         }
     }
@@ -447,7 +446,6 @@ public class GeoserverRestApi {
             }
         } catch (Exception e) {
             logger.error("Failed to Delete to geoserver rest api", e);
-            System.out.println(e);
             return false;
         }
         return isDeleted;

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverRestApi.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverRestApi.java
@@ -1,3 +1,12 @@
+/*******************************************************************************
+ * Copyright (c) 2019 University of Illinois and others.  All rights reserved.
+ * This program and the accompanying materials are made available under the
+ * terms of the Mozilla Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.mozilla.org/en-US/MPL/2.0/
+ *
+ *   Contributors:
+ *   Yong Wook Kim (NCSA) - initial API and implementation
+ *******************************************************************************/
 package edu.illinois.ncsa.incore.service.data.utils;
 
 import org.apache.commons.io.FilenameUtils;

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverRestApi.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverRestApi.java
@@ -215,6 +215,7 @@ public class GeoserverRestApi {
                 published = true;
             }
         } catch (IOException e) {
+            logger.error("Failed to upload to geoserver with renaming", e);
             throw new RuntimeException(e);
         }
 

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverRestApi.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverRestApi.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 University of Illinois and others.  All rights reserved.
+ * Copyright (c) 2024 University of Illinois and others.  All rights reserved.
  * This program and the accompanying materials are made available under the
  * terms of the Mozilla Public License v2.0 which accompanies this distribution,
  * and is available at https://www.mozilla.org/en-US/MPL/2.0/

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverUtils.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/GeoserverUtils.java
@@ -59,7 +59,8 @@ public class GeoserverUtils {
                 double[] bbox = GeotoolsUtils.getBboxFromShp(new File(fileName));
                 dataset.setBoundingBox(bbox);
                 repository.addDataset(dataset);
-                published = gsApi.uploadToGeoserver(datasetId, outFile, inExt);
+                // layer in geoserver doesn't have to be renamed
+                published = gsApi.uploadToGeoserver(datasetId, outFile, inExt, false);
             } else if (isTif == true || isAsc == true) {
                 if (isTif) {
                     inExt = "tif";
@@ -70,7 +71,8 @@ public class GeoserverUtils {
                 double[] bbox = GeotoolsUtils.getBboxFromGrid(outFile);
                 dataset.setBoundingBox(bbox);
                 repository.addDataset(dataset);
-                published = gsApi.uploadToGeoserver(datasetId, outFile, inExt);
+                // layer in geoserver doesn't have to be renamed
+                published = gsApi.uploadToGeoserver(datasetId, outFile, inExt, false);
             }
         }
 
@@ -100,8 +102,9 @@ public class GeoserverUtils {
             double[] bbox = GeotoolsUtils.getBboxFromShp(new File(linkFileName));
             dataset.setBoundingBox(bbox);
             repository.addDataset(dataset);
-            link_published = gsApi.uploadToGeoserver(datasetId, outFiles[0], inExt);
-            node_published = gsApi.uploadToGeoserver(datasetId, outFiles[1], inExt);
+            // layer in geoserver doesn't have to be renamed
+            link_published = gsApi.uploadToGeoserver(datasetId, outFiles[0], inExt, false);
+            node_published = gsApi.uploadToGeoserver(datasetId, outFiles[1], inExt, false);
 
         }
 
@@ -131,7 +134,8 @@ public class GeoserverUtils {
      */
     public static boolean uploadGpkgToGeoserver(String store, File gpkgFile) {
         GeoserverRestApi gsApi = GeoserverRestApi.createGeoserverApi();
-        boolean isPublished = gsApi.uploadToGeoserver(store, gpkgFile, "gpkg");
+        // layer in geoserver doesn't have to be renamed to dataset id
+        boolean isPublished = gsApi.uploadToGeoserver(store, gpkgFile, "gpkg", true);
 
         return isPublished;
     }


### PR DESCRIPTION
Please test with the attached zip file. 
After unzip it, you will see one geopackage file (guid_test.gpkg) and others that are shapefile component (epn_guid.shp)

[data.zip](https://github.com/IN-CORE/incore-services/files/14104257/data.zip)

Test posting both dataset
 
Testing GeoPackage
1. create a dataset with 
{"format": "geopackage", "title": "test-delete", "description": "delete me", "dataType": "incore:addressPoints"} 
please ignore dataType, this is just a test
2. attach geopackage file to the dataset created in step 1
3. if attach process is successful, the PR is good
4. remove the dataset created in step 1

Testing Shapefile
1. create a dataset with
{"format": "shapefile", "title": "test-delete", "description": "delete me", "dataType": "incore:addressPoints"} 
please ignore dataType, this is just a test
2. attach shpefile components (.shp, .dbf, .shx, .prj) to the dataset created in step 1
3. if attach process is successful, the PR is good
4. remove the dataset created in step 1