### PR TITLE
Fixes #289 Hazard dataset quota usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Hazard dataset user quota to check type name after the namespace when determining if a dataset is a hazard dataset [#289](https://github.com/IN-CORE/incore-services/issues/289)
+
 ## [1.26.0] - 2024-03-27
 
 ### Changed

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
@@ -147,7 +147,7 @@ public class DatasetController {
             return dataset;
         }
 
-        if (authorizer.canUserReadMember(this.username, datasetId, spaceRepository.getAllSpaces(),this.groups)) {
+        if (authorizer.canUserReadMember(this.username, datasetId, spaceRepository.getAllSpaces(), this.groups)) {
             return dataset;
         }
         throw new IncoreHTTPException(Response.Status.FORBIDDEN,
@@ -166,7 +166,7 @@ public class DatasetController {
                                      @Parameter(name = "Specify the order of sorting, either ascending or descending.") @DefaultValue("desc") @QueryParam("order") String order,
                                      @Parameter(name = "Skip the first n results") @QueryParam("skip") int offset,
                                      @Parameter(name = "Limit no of results to return") @DefaultValue("100") @QueryParam("limit") int limit,
-                                     @Parameter(name = "Exclusion of the hazard dataset") @DefaultValue("true") @QueryParam("excludeHazard") boolean excludeHazard ){
+                                     @Parameter(name = "Exclusion of the hazard dataset") @DefaultValue("true") @QueryParam("excludeHazard") boolean excludeHazard) {
 
         // import eq comparator
         Comparator<Dataset> comparator = datasetComparator(sortBy, order);
@@ -191,7 +191,7 @@ public class DatasetController {
             if (space == null) {
                 throw new IncoreHTTPException(Response.Status.NOT_FOUND, "Could not find the space " + spaceName);
             }
-            if (!authorizer.canRead(username, space.getPrivileges(),this.groups)) {
+            if (!authorizer.canRead(username, space.getPrivileges(), this.groups)) {
                 throw new IncoreHTTPException(Response.Status.FORBIDDEN, username + " is not authorized to read the space " + spaceName);
             }
             List<String> spaceMembers = space.getMembers();
@@ -209,7 +209,7 @@ public class DatasetController {
             return datasets;
         }
         //get all datasets that the user can read
-        Set<String> userMembersSet = authorizer.getAllMembersUserHasReadAccessTo(username, spaceRepository.getAllSpaces(),groups);
+        Set<String> userMembersSet = authorizer.getAllMembersUserHasReadAccessTo(username, spaceRepository.getAllSpaces(), groups);
 
         //return the intersection between all datasets and the ones the user can read
         List<Dataset> accessibleDatasets = datasets.stream()
@@ -386,8 +386,16 @@ public class DatasetController {
             dataset.setSourceDataset(sourceDataset);
             dataset.setFormat(format);
 
+            String subDataType;
+            if (dataType.contains(":")) {
+                // Compare what comes after the name space (e.g. probabilisticEarthquakeRaster from ergo:probabilisticEarthquakeRaster)
+                subDataType = dataType.split(":")[1];
+            } else {
+                subDataType = dataType;
+            }
+
             // check if the dataset is hazard dataset
-            isHazardDataset = HazardConstants.DATA_TYPE_HAZARD.contains(dataType);
+            isHazardDataset = HazardConstants.DATA_TYPE_HAZARD.stream().anyMatch(s1 -> s1.contains(subDataType));
 
             if (isHazardDataset) {
                 postOk = AllocationUtils.canCreateAnyDataset(allocationsRepository, quotaRepository, username, "hazardDatasets");
@@ -500,7 +508,14 @@ public class DatasetController {
 
         // check if the dataset is hazard dataset
         String dataType = dataset.getDataType();
-        boolean isHazardDataset = HazardConstants.DATA_TYPE_HAZARD.contains(dataType);
+        String subDataType;
+        if (dataType.contains(":")) {
+            // Compare what comes after the name space (e.g. probabilisticEarthquakeRaster from ergo:probabilisticEarthquakeRaster)
+            subDataType = dataType.split(":")[1];
+        } else {
+            subDataType = dataType;
+        }
+        boolean isHazardDataset = HazardConstants.DATA_TYPE_HAZARD.stream().anyMatch(s1 -> s1.contains(subDataType));
 
         // reduce the number of hazard from the space
         if (isHazardDataset) {
@@ -527,8 +542,8 @@ public class DatasetController {
     public Dataset uploadFiles(@Parameter(name = "Dataset Id from data service", required = true) @PathParam("id") String datasetId,
                                @Parameter(name = "Form inputs representing the file(s). The id/key of each input file has to be 'file'",
                                    required = true)
-                                   FormDataMultiPart inputs) throws IOException {
-        if (!authorizer.canUserWriteMember(this.username, datasetId, spaceRepository.getAllSpaces(),this.groups)) {
+                               FormDataMultiPart inputs) throws IOException {
+        if (!authorizer.canUserWriteMember(this.username, datasetId, spaceRepository.getAllSpaces(), this.groups)) {
             throw new IncoreHTTPException(Response.Status.FORBIDDEN,
                 this.username + " has no permission to modify the dataset " + datasetId);
         }
@@ -546,7 +561,15 @@ public class DatasetController {
 
         // check if the dataset is hazard dataset
         String dataType = dataset.getDataType();
-        isHazardDataset = HazardConstants.DATA_TYPE_HAZARD.contains(dataType);
+        String subDataType;
+        if (dataType.contains(":")) {
+            // Compare what comes after the name space (e.g. probabilisticEarthquakeRaster from ergo:probabilisticEarthquakeRaster)
+            subDataType = dataType.split(":")[1];
+        } else {
+            subDataType = dataType;
+        }
+        isHazardDataset = HazardConstants.DATA_TYPE_HAZARD.stream().anyMatch(s1 -> s1.contains(subDataType));
+
         long fileSize = 0;
 
         if (isHazardDataset) {
@@ -1066,7 +1089,7 @@ public class DatasetController {
             datasets = this.repository.searchDatasets(text, excludeHazard);
         }
 
-        Set<String> membersSet = authorizer.getAllMembersUserHasReadAccessTo(this.username, spaceRepository.getAllSpaces(),this.groups);
+        Set<String> membersSet = authorizer.getAllMembersUserHasReadAccessTo(this.username, spaceRepository.getAllSpaces(), this.groups);
 
         datasets = datasets.stream()
             .filter(dataset -> membersSet.contains(dataset.getId()))

--- a/server/data-service/src/test/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetControllerTest.java
+++ b/server/data-service/src/test/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetControllerTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package edu.illinois.ncsa.incore.service.data.controllers;
 
+import edu.illinois.ncsa.incore.common.HazardConstants;
 import edu.illinois.ncsa.incore.service.data.models.Dataset;
 import mocks.MockApplication;
 import org.apache.commons.io.IOUtils;
@@ -139,5 +140,49 @@ class DatasetControllerTest extends CustomJerseyTest {
         assertNotNull(parsedObject.get("id").toString());
     }
 
+    @Test
+    public void testFindHazardDatasetType() throws IOException {
+        String dataType = "ergo:probabilisticEarthquakeRaster";
+        String subDataType;
+        if (dataType.contains(":")) {
+            // Compare what comes after the name space (e.g. probabilisticEarthquakeRaster from ergo:probabilisticEarthquakeRaster)
+            subDataType = dataType.split(":")[1];
+        } else {
+            subDataType = dataType;
+        }
+
+        // check if the dataset is hazard dataset
+        boolean isHazardDataset = HazardConstants.DATA_TYPE_HAZARD.stream().anyMatch(s1 -> s1.contains(subDataType));
+        assertTrue(isHazardDataset);
+    }
+
+    @Test
+    public void testFindHazardDatasetTypeWithBadDataType() throws IOException {
+        String dataType = "probabilisticEarthquakeRaster";
+        String subDataType;
+        if (dataType.contains(":")) {
+            // Compare what comes after the name space (e.g. probabilisticEarthquakeRaster from ergo:probabilisticEarthquakeRaster)
+            subDataType = dataType.split(":")[1];
+        } else {
+            subDataType = dataType;
+        }
+
+        // check if the dataset is hazard dataset
+        boolean isHazardDataset = HazardConstants.DATA_TYPE_HAZARD.stream().anyMatch(s1 -> s1.contains(subDataType));
+        assertTrue(isHazardDataset);
+
+        dataType = "ergo:buildingDamageVer4";
+        String subDataType2;
+        if (dataType.contains(":")) {
+            // Compare what comes after the name space (e.g. probabilisticEarthquakeRaster from ergo:probabilisticEarthquakeRaster)
+            subDataType2 = dataType.split(":")[1];
+        } else {
+            subDataType2 = dataType;
+        }
+
+        // check if the dataset is hazard dataset
+        isHazardDataset = HazardConstants.DATA_TYPE_HAZARD.stream().anyMatch(s1 -> s1.contains(subDataType2));
+        assertFalse(isHazardDataset);
+    }
 
 }


### PR DESCRIPTION
This fixes the increase/decrease of a user quota when adding/deleting hazards by checking only the type after the namespace so whether something is ergo:deterministicHazardRaster or ncsa:deterministicHazardRaster it should increase/decrease correctly. 

I also added unit tests.