### PR TITLE
Fixes #303 updated all jackson library references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Jersey to version 3.1.7 [#250](https://github.com/IN-CORE/incore-services/issues/250)
+- Jackson library to 2.17.0 [#303](https://github.com/IN-CORE/incore-services/issues/303)
 
 ## [1.26.1] - 2024-04-08
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -157,7 +157,7 @@ test {
             implementation("com.sun.activation:javax.activation:1.2.0")
             implementation("de.grundid.opendatalab:geojson-jackson:1.8")
             implementation("org.jamel.dbf:dbf-reader:0.2.0")
-            implementation("org.dom4j:dom4j:2.1.1")
+            implementation("org.dom4j:dom4j:2.1.3")
 
             //base jersey and jackson
             implementation("jakarta.ws.rs:jakarta.ws.rs-api:3.1.0")

--- a/server/data-service/build.gradle
+++ b/server/data-service/build.gradle
@@ -17,12 +17,12 @@ dependencies {
 
     implementation("org.jsoup:jsoup:1.16.1")
     implementation("com.github.lookfirst:sardine:5.12")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.15.2")
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.17.0")
 
     implementation("junit:junit:4.13.2")
 
     // the packages below are not used in the code, but we need to test it
-    
+
     //implementation group: 'org.apache.httpcomponents', name: 'httpmime', version: '4.5.5'
     //implementation group: 'com.google.code.gson', name: 'gson', version: '2.2.4'
     //implementation group: 'org.apache.commons', name: 'commons-io', version: '1.3.2'

--- a/server/incore-common/build.gradle
+++ b/server/incore-common/build.gradle
@@ -12,7 +12,7 @@ repositories {
 dependencies {
     implementation("com.googlecode.json-simple:json-simple:1.1.1")
 
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.10.5")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.17.0")
     //mongo
     implementation("dev.morphia.morphia:morphia-core:2.1.3")
 
@@ -27,7 +27,7 @@ dependencies {
     implementation("org.glassfish.jersey.media:jersey-media-json-jackson:$jerseyVersion")
     implementation("org.glassfish.jersey.media:jersey-media-multipart:$jerseyVersion")
     implementation("org.glassfish.jersey.inject:jersey-hk2:$jerseyVersion")
- 
+
     // JUnit 5
     testImplementation(group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.1.0')
 

--- a/server/semantic-core/build.gradle
+++ b/server/semantic-core/build.gradle
@@ -9,13 +9,14 @@ compileTestJava.options.encoding = 'UTF-8'
 
 // In this section you declare the dependencies for your production and test code
 dependencies {
+    //versions
     implementation group: 'org.jgrapht', name: 'jgrapht-core', version: '1.0.1'
     implementation group: 'org.apache.jena', name: 'jena-core', version: '3.1.1'
 
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.9.0'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.0'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.9.0'
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.9.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.17.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.17.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.17.0'
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.17.0'
 
     implementation group: 'org.javamoney', name: 'moneta', version: '1.1'
 

--- a/server/tools-common/build.gradle
+++ b/server/tools-common/build.gradle
@@ -2,6 +2,6 @@ apply plugin: 'java'
 
 dependencies {
     implementation 'commons-lang:commons-lang:2.6'
-    implementation 'org.dom4j:dom4j:2.0.0'
+    implementation 'org.dom4j:dom4j:2.1.3'
     implementation 'log4j:log4j:1.2.17.norce'
 }


### PR DESCRIPTION
There were multiple versions of Jackson being used (most were using 2.17.0) so I made them all use 2.17.0. Dom4j had a recommended upgrade to 2.1.3 (we were using both 2.1.1  and 2.0.0) so I made them both 2.1.3.