### PR TITLE
Fixes #325 - Earthquake hazard visualization bounding box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Earthquake hazard visualization bounding box [#325](https://github.com/IN-CORE/incore-services/issues/325)
+
 ## [1.27.0] - 2024-10-24
 ### Added
 - Implement Project endpoints [#307](https://github.com/IN-CORE/incore-services/issues/307)

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
@@ -423,7 +423,7 @@ public class HazardCalc {
 
         // Get default demand units for the hazard type
         String demandUnits = BaseAttenuation.getUnits(demandComponents[1]);
-        ReferencedEnvelope envelope = new ReferencedEnvelope(minX, minY, width * cellsize, height * cellsize, crs);
+        ReferencedEnvelope envelope = new ReferencedEnvelope(minX, minX + width * cellsize, minY, minY + height * cellsize, crs);
         for (int y = 0; y < height; y++) {
 
             startX = (float) minX + (cellsize / 2.0f);


### PR DESCRIPTION
A bug was introduced by using the reference envelope, which expects x1, x2, y1, y2 whereas the previous expected x1, y1, width, height. This looks to fix the issue, but please check if this is correct. 