### PR TITLE
330 add sortedby and order to all project endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added
+- Sorted by option and order to the all project endpoints [#330](https://github.com/IN-CORE/incore-services/issues/330)
+
 ## [1.27.1] - 2024-11-01
 ### Fixed
 - Earthquake hazard visualization bounding box [#325](https://github.com/IN-CORE/incore-services/issues/325)

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/DFR3MappingResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/DFR3MappingResource.java
@@ -3,6 +3,7 @@ package edu.illinois.ncsa.incore.service.project.models;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -27,6 +28,8 @@ public class DFR3MappingResource extends ProjectResource {
 
     private Type type = Type.fragility;
     private String mappingType;
+
+    public Date date = new Date();
 
     public String name;
     public String hazardType;
@@ -65,6 +68,14 @@ public class DFR3MappingResource extends ProjectResource {
 
     public void setType(Type type) {
         this.type = type;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public Date getDate() {
+        return date;
     }
 
     public void setHazardType(String hazardType) {

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/DFR3MappingResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/DFR3MappingResource.java
@@ -78,6 +78,14 @@ public class DFR3MappingResource extends ProjectResource {
         return date;
     }
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
     public void setHazardType(String hazardType) {
         this.hazardType = hazardType;
     }

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/DFR3MappingResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/DFR3MappingResource.java
@@ -67,6 +67,22 @@ public class DFR3MappingResource extends ProjectResource {
         this.type = type;
     }
 
+    public void setHazardType(String hazardType) {
+        this.hazardType = hazardType;
+    }
+
+    public String getHazardType() {
+        return hazardType;
+    }
+
+    public void setInventoryType(String inventoryType) {
+        this.inventoryType = inventoryType;
+    }
+
+    public String getInventoryType() {
+        return inventoryType;
+    }
+
     public boolean matchesSearchText(String text) {
         String lowerCaseText = text.toLowerCase();
         return (this.getId() != null && this.getId().equals(lowerCaseText)) ||

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/DatasetResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/DatasetResource.java
@@ -42,6 +42,14 @@ public class DatasetResource extends ProjectResource{
         return dataType;  // Fallback to dataType if type is null or empty
     }
 
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
     // Setter for type
     public void setType(String type) {
         this.type = type;

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/HazardResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/HazardResource.java
@@ -24,7 +24,7 @@ public class HazardResource extends ProjectResource {
     public Type type = Type.earthquake;
 
     // Only keep basic information for now
-    public String name;
+    public String name = null;
     public String description;
     public Date date = new Date();
     public String creator = null;
@@ -41,6 +41,22 @@ public class HazardResource extends ProjectResource {
 
     public void setType(Type type) {
         this.type = type;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setCreator(String creator) {
+        this.creator = creator;
+    }
+
+    public String getCreator() {
+        return creator;
     }
 
     @JsonSerialize(using = JsonDateSerializer.class)

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/VisualizationResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/VisualizationResource.java
@@ -117,8 +117,6 @@ public class VisualizationResource extends ProjectResource{
         return name;
     }
 
-
-
     public boolean matchesSearchText(String text) {
         String lowerCaseText = text.toLowerCase();
         return (this.getId() != null && this.getId().equals(lowerCaseText)) ||

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/VisualizationResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/VisualizationResource.java
@@ -109,6 +109,16 @@ public class VisualizationResource extends ProjectResource{
         sourceDatasetIds.remove(id);
     }
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+
+
     public boolean matchesSearchText(String text) {
         String lowerCaseText = text.toLowerCase();
         return (this.getId() != null && this.getId().equals(lowerCaseText)) ||

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/WorkflowResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/WorkflowResource.java
@@ -1,5 +1,6 @@
 package edu.illinois.ncsa.incore.service.project.models;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.Date;
@@ -17,18 +18,21 @@ public class WorkflowResource extends ProjectResource {
     public Type type = Type.workflow; // default to workflow
     public boolean isFinalized = false;
 
-    // only keep basic field
+    // Only keep basic fields
     public boolean deleted;
     public String title;
     public String description;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZ", timezone = "UTC")
     public Date created;
+
     public WorkflowCreator creator;
     public List<String> contributors;
 
     public WorkflowResource() {
     }
 
-    // Getter and Setter for hazardType
+    // Getter and Setter for type
     public Type getType() {
         return type;
     }
@@ -37,6 +41,23 @@ public class WorkflowResource extends ProjectResource {
         this.type = type;
     }
 
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    // Search functionality
     public boolean matchesSearchText(String text) {
         String lowerCaseText = text.toLowerCase();
         return (this.getId() != null && this.getId().equals(lowerCaseText)) ||

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/WorkflowResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/WorkflowResource.java
@@ -18,7 +18,7 @@ public class WorkflowResource extends ProjectResource {
     public Type type = Type.workflow; // default to workflow
     public boolean isFinalized = false;
 
-    // Only keep basic fields
+    // only keep basic field
     public boolean deleted;
     public String title;
     public String description;

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/utils/CommonUtil.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/utils/CommonUtil.java
@@ -102,6 +102,9 @@ public class CommonUtil {
             case "id":
                 comparator = Comparator.comparing(DFR3MappingResource::getId);
                 break;
+            case "name":
+                comparator = Comparator.comparing(DFR3MappingResource::getName);
+                break;
             case "date":
             default:
                 comparator = Comparator.comparing(DFR3MappingResource::getDate);

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/utils/CommonUtil.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/utils/CommonUtil.java
@@ -1,0 +1,31 @@
+package edu.illinois.ncsa.incore.service.project.utils;
+
+import java.util.Comparator;
+import edu.illinois.ncsa.incore.service.project.models.Project;
+
+public class CommonUtil {
+    // Method to get the comparator based on sortBy and order
+    public static <T> Comparator<T> projectComparator(String sortBy, String order) {
+        Comparator<T> comparator;
+
+        switch (sortBy.toLowerCase()) {
+            case "name":
+                comparator = Comparator.comparing(resource -> ((Project) resource).getName());
+                break;
+            case "creator":
+                comparator = Comparator.comparing(resource -> ((Project) resource).getCreator());
+                break;
+            case "date":
+            default:
+                comparator = Comparator.comparing(resource -> ((Project) resource).getDate());
+                break;
+        }
+
+        if ("desc".equalsIgnoreCase(order)) {
+            comparator = comparator.reversed();
+        }
+
+        return comparator;
+    }
+
+}

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/utils/CommonUtil.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/utils/CommonUtil.java
@@ -1,23 +1,54 @@
 package edu.illinois.ncsa.incore.service.project.utils;
 
 import java.util.Comparator;
-import edu.illinois.ncsa.incore.service.project.models.Project;
+
+import edu.illinois.ncsa.incore.service.project.models.*;
 
 public class CommonUtil {
     // Method to get the comparator based on sortBy and order
-    public static <T> Comparator<T> projectComparator(String sortBy, String order) {
-        Comparator<T> comparator;
+    public static Comparator<Project> projectComparator(String sortBy, String order) {
+        Comparator<Project> comparator;
 
         switch (sortBy.toLowerCase()) {
             case "name":
-                comparator = Comparator.comparing(resource -> ((Project) resource).getName());
+                comparator = Comparator.comparing(Project::getName);
                 break;
             case "creator":
-                comparator = Comparator.comparing(resource -> ((Project) resource).getCreator());
+                comparator = Comparator.comparing(Project::getCreator);
                 break;
             case "date":
             default:
-                comparator = Comparator.comparing(resource -> ((Project) resource).getDate());
+                comparator = Comparator.comparing(Project::getDate);
+                break;
+        }
+
+        // If order is "desc", reverse the comparator
+        if ("desc".equalsIgnoreCase(order)) {
+            comparator = comparator.reversed();
+        }
+
+        return comparator;
+    }
+
+    public static Comparator<HazardResource> hazardComparator(String sortBy, String order) {
+        Comparator<HazardResource> comparator;
+
+        switch (sortBy.toLowerCase()) {
+            case "type":
+                comparator = Comparator.comparing(HazardResource::getType);
+                break;
+            case "id":
+                comparator = Comparator.comparing(HazardResource::getId);
+                break;
+            case "name":
+                comparator = Comparator.comparing(HazardResource::getName);
+                break;
+            case "creator":
+                comparator = Comparator.comparing(HazardResource::getCreator);
+                break;
+            case "date":
+            default:
+                comparator = Comparator.comparing(HazardResource::getDate);
                 break;
         }
 
@@ -27,5 +58,111 @@ public class CommonUtil {
 
         return comparator;
     }
+
+
+    public static Comparator<DatasetResource> datasetComparator(String sortBy, String order) {
+        Comparator<DatasetResource> comparator;
+
+        switch (sortBy.toLowerCase()) {
+            case "title":
+                comparator = Comparator.comparing(DatasetResource::getTitle);
+                break;
+            case "type":
+                comparator = Comparator.comparing(DatasetResource::getDataType);
+                break;
+            case "id":
+                comparator = Comparator.comparing(DatasetResource::getId);
+                break;
+            case "date":
+            default:
+                comparator = Comparator.comparing(DatasetResource::getDate);
+                break;
+        }
+
+        if ("desc".equalsIgnoreCase(order)) {
+            comparator = comparator.reversed();
+        }
+
+        return comparator;
+    }
+
+    public static Comparator<DFR3MappingResource> dfr3MappingComparator(String sortBy, String order) {
+        Comparator<DFR3MappingResource> comparator;
+
+        switch (sortBy.toLowerCase()) {
+            case "hazardtype":
+                comparator = Comparator.comparing(DFR3MappingResource::getHazardType, Comparator.nullsLast(String::compareToIgnoreCase));
+                break;
+            case "inventorytype":
+                comparator = Comparator.comparing(DFR3MappingResource::getInventoryType, Comparator.nullsLast(String::compareToIgnoreCase));
+                break;
+            case "type":
+            default:
+                comparator = Comparator.comparing(DFR3MappingResource::getType);
+                break;
+            case "id":
+                comparator = Comparator.comparing(DFR3MappingResource::getId);
+                break;
+        }
+
+        if ("desc".equalsIgnoreCase(order)) {
+            comparator = comparator.reversed();
+        }
+
+        return comparator;
+    }
+
+    public static Comparator<WorkflowResource> workflowComparator(String sortBy, String order) {
+        Comparator<WorkflowResource> comparator;
+
+        switch (sortBy.toLowerCase()) {
+            case "type":
+                comparator = Comparator.comparing(WorkflowResource::getType);
+                break;
+            case "id":
+                comparator = Comparator.comparing(WorkflowResource::getId);
+                break;
+            case "title":
+                comparator = Comparator.comparing(WorkflowResource::getTitle, Comparator.nullsLast(String::compareToIgnoreCase));
+                break;
+            case "created":
+            default:
+                comparator = Comparator.comparing(WorkflowResource::getCreated, Comparator.nullsLast(Comparator.naturalOrder()));
+                break;
+        }
+
+        if ("desc".equalsIgnoreCase(order)) {
+            comparator = comparator.reversed();
+        }
+
+        return comparator;
+    }
+
+    public static Comparator<VisualizationResource> visualizationComparator(String sortBy, String order) {
+        Comparator<VisualizationResource> comparator;
+
+        switch (sortBy.toLowerCase()) {
+            case "type":
+                comparator = Comparator.comparing(VisualizationResource::getType);
+                break;
+            case "id":
+                comparator = Comparator.comparing(VisualizationResource::getId, Comparator.nullsLast(String::compareToIgnoreCase));
+                break;
+            case "name":
+                comparator = Comparator.comparing(VisualizationResource::getName, Comparator.nullsLast(String::compareToIgnoreCase));
+                break;
+            case "date":
+            default:
+                comparator = Comparator.comparing(VisualizationResource::getDate, Comparator.nullsLast(Comparator.naturalOrder()));
+                break;
+        }
+
+        if ("desc".equalsIgnoreCase(order)) {
+            comparator = comparator.reversed();
+        }
+
+        return comparator;
+    }
+
 
 }

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/utils/CommonUtil.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/utils/CommonUtil.java
@@ -169,6 +169,5 @@ public class CommonUtil {
 
         return comparator;
     }
-
-
+    
 }

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/utils/CommonUtil.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/utils/CommonUtil.java
@@ -97,11 +97,14 @@ public class CommonUtil {
                 comparator = Comparator.comparing(DFR3MappingResource::getInventoryType, Comparator.nullsLast(String::compareToIgnoreCase));
                 break;
             case "type":
-            default:
                 comparator = Comparator.comparing(DFR3MappingResource::getType);
                 break;
             case "id":
                 comparator = Comparator.comparing(DFR3MappingResource::getId);
+                break;
+            case "date":
+            default:
+                comparator = Comparator.comparing(DFR3MappingResource::getDate);
                 break;
         }
 


### PR DESCRIPTION
New sortedBy and order parameters added to the following project endpoints 

- GET /project/api/projects
- GET project/api/projects/{project-id}/hazards
- GET project/api/projects/{project-id}/visualizations
- GET project/api/projects/{project-id}/datasets
- GET project/api/projects/{project-id}/workflows
- GET project/api/projects/{project-id}/mappings

Default to sort by “Date”
Default to sort by descending order. Latest items show up first

How to test
- http://localhost:8080/project/api/projects?sortBy=date&order=desc (the result should be identical without any sortBy option since it is default. But you can change it to asec to test it)
- http://localhost:8080/project/api/projects/673b789f74c21f67fa69003b/datasets?sortBy=title&order=desc
- http://localhost:8080/project/api/projects/673b789f74c21f67fa69003b/hazards?sortBy=creator&order=desc

There are other options and endpoints so please test various options.


