### PR TITLE
331 fix bug adding vis layers to empty layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Sorted by option and order to the all project endpoints [#330](https://github.com/IN-CORE/incore-services/issues/330)
 
+### Fixed
+- Bug when adding visualization layers to an empty layer list [#331](https://github.com/IN-CORE/incore-services/issues/331)
+
 ## [1.27.1] - 2024-11-01
 ### Fixed
 - Earthquake hazard visualization bounding box [#325](https://github.com/IN-CORE/incore-services/issues/325)

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/controllers/ProjectController.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/controllers/ProjectController.java
@@ -954,6 +954,31 @@ public class ProjectController {
     }
 
     @GET
+    @Path("{projectId}/visualizations/{visualizationId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(description = "Get a specific visualization belongs to a project")
+    public VisualizationResource getVisualizationOfProject(
+        @Parameter(name = "projectId", description = "ID of the project.") @PathParam("projectId") String id,
+        @Parameter(name = "visualizationId", description = "ID of the visualization.") @PathParam("visualizationId") String visualizationId) {
+        Project project = projectDAO.getProjectById(id);
+        if (project != null) {
+            if (authorizer.canUserReadMember(username, id, spaceRepository.getAllSpaces(), groups)) {
+                Optional<VisualizationResource> projectFound = project.getVisualizations().stream()
+                    .filter(visualization -> visualization.getId().toString().equalsIgnoreCase(visualizationId)).findFirst();
+                if (projectFound.isPresent()) {
+                    return projectFound.get();
+                } else {
+                    throw new IncoreHTTPException(Response.Status.NOT_FOUND, "Could not find a visualization with id " + visualizationId);
+                }
+            } else {
+                throw new IncoreHTTPException(Response.Status.FORBIDDEN, this.username + " does not have privileges to access the " +
+                    "project with id " + id);
+            }
+        }
+        throw new IncoreHTTPException(Response.Status.NOT_FOUND, "Could not find a project with id " + id);
+    }
+
+    @GET
     @Path("{projectId}/visualizations/search")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Search visualizations from a project")

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/DatasetResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/DatasetResource.java
@@ -1,8 +1,6 @@
 package edu.illinois.ncsa.incore.service.project.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import edu.illinois.ncsa.incore.common.data.models.jackson.JsonDateSerializer;
 
 import java.util.List;
 

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/DatasetResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/DatasetResource.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import edu.illinois.ncsa.incore.common.data.models.jackson.JsonDateSerializer;
 
-import java.util.Date;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -16,7 +15,6 @@ public class DatasetResource extends ProjectResource{
     public boolean deleted = false;
     public String title;
     public String description = "";
-    public Date date = new Date();
     public String creator = null;
     public String owner = null;
     public List<String> contributors = null;
@@ -54,11 +52,6 @@ public class DatasetResource extends ProjectResource{
 
     public void setDataType(String dataType) {
         this.dataType = dataType;
-    }
-
-    @JsonSerialize(using = JsonDateSerializer.class)
-    public Date getDate() {
-        return date;
     }
 
     public boolean matchesSearchText(String text) {

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/HazardResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/HazardResource.java
@@ -1,6 +1,7 @@
 package edu.illinois.ncsa.incore.service.project.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.util.List;
 
 
@@ -51,11 +52,6 @@ public class HazardResource extends ProjectResource {
 
     public String getCreator() {
         return creator;
-    }
-
-    @JsonSerialize(using = JsonDateSerializer.class)
-    public Date getDate() {
-        return date;
     }
 
     public boolean matchesSearchText(String text) {

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/HazardResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/HazardResource.java
@@ -1,10 +1,6 @@
 package edu.illinois.ncsa.incore.service.project.models;
 
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import edu.illinois.ncsa.incore.common.data.models.jackson.JsonDateSerializer;
-
 import java.util.List;
 
 

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/HazardResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/HazardResource.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import edu.illinois.ncsa.incore.common.data.models.jackson.JsonDateSerializer;
 
-import java.util.Date;
 import java.util.List;
 
 
@@ -26,7 +25,6 @@ public class HazardResource extends ProjectResource {
     // Only keep basic information for now
     public String name;
     public String description;
-    public Date date = new Date();
     public String creator = null;
     public String owner = null;
     public List<HazardDataset> hazardDatasets;
@@ -41,11 +39,6 @@ public class HazardResource extends ProjectResource {
 
     public void setType(Type type) {
         this.type = type;
-    }
-
-    @JsonSerialize(using = JsonDateSerializer.class)
-    public Date getDate() {
-        return date;
     }
 
     public boolean matchesSearchText(String text) {

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/Mapping.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/Mapping.java
@@ -19,5 +19,4 @@ import java.util.Map;
 public class Mapping {
     public final Map<String, String> legacyEntry = new HashMap<>();
     public final Map<String, String> entry = new HashMap<>();
-    public final Object rules = new Object();
 }

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/ProjectResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/ProjectResource.java
@@ -1,7 +1,11 @@
 package edu.illinois.ncsa.incore.service.project.models;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import dev.morphia.annotations.Embedded;
+import edu.illinois.ncsa.incore.common.data.models.jackson.JsonDateSerializer;
 import org.bson.types.ObjectId;
+
+import java.util.Date;
 
 
 @Embedded

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/ProjectResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/ProjectResource.java
@@ -35,6 +35,17 @@ public class ProjectResource {
         this.id = id;
     }
 
+    public Date date = new Date();
+
+    @JsonSerialize(using = JsonDateSerializer.class)
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
 //    public Status getStatus() {
 //        return status;
 //    }

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/VisualizationResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/VisualizationResource.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import edu.illinois.ncsa.incore.common.data.models.jackson.JsonDateSerializer;
 
-import java.util.Date;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -25,16 +24,10 @@ public class VisualizationResource extends ProjectResource{
     private List<String> sourceDatasetIds = null;
     public String name;
     public String description;
-    public Date date = new Date();
 
     public VisualizationResource() {}
     public VisualizationResource(Type type) {
         this.type = type;
-    }
-
-    @JsonSerialize(using = JsonDateSerializer.class)
-    public Date getDate() {
-        return date;
     }
 
     public Type getType() {

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/VisualizationResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/VisualizationResource.java
@@ -2,8 +2,6 @@ package edu.illinois.ncsa.incore.service.project.models;
 
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import edu.illinois.ncsa.incore.common.data.models.jackson.JsonDateSerializer;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/VisualizationResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/VisualizationResource.java
@@ -57,6 +57,10 @@ public class VisualizationResource extends ProjectResource{
     }
 
     public void addLayer(Layer layer) {
+        if (layers == null) {
+            layers = new ArrayList<>();
+        }
+
         // Check if the layer already exists in the list
         boolean exists = layers.stream()
             .anyMatch(existingLayer -> existingLayer.getLayerId().equals(layer.getLayerId()));

--- a/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/VisualizationResource.java
+++ b/server/project-service/src/main/java/edu/illinois/ncsa/incore/service/project/models/VisualizationResource.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import edu.illinois.ncsa.incore.common.data.models.jackson.JsonDateSerializer;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -19,7 +20,7 @@ public class VisualizationResource extends ProjectResource{
 
     private Type type = Type.MAP;
     private double[] boundingBox = null;
-    private List<Layer> layers = null;
+    private List<Layer> layers = new ArrayList<>();
     private String vegaJson = null;
     private List<String> sourceDatasetIds = null;
     public String name;


### PR DESCRIPTION
- Default empty layers to a list
- Fix logic to add layers to an empty layer object
- Add new endpoint to get specific visualization GET `/project/api/projects/{projectId}/visualizations/{visualizationId}`
- Cosmetic: move the common field date to parent class "projectResource" that ensures all resource will have a date field

TEST:
- Post a new project: POST `/project/api/projects` 
```
{
  "name": "Example Project",
  "description": "This is a description of the example project.",
  "region": "Joplin"
}
```

- Create a empty visualization POST `/project/api/projects/{projectId}/visualizations`
```
[
    {
    "name": "INCORE Maps",
    "description": "Layers of incore maps",
    "type": "MAP",
    "boundingBox": [
        -90.07376669874641,
        35.03298062856903,
        -89.71464767735003,
        35.207753220358086
    ]
}]
```

- Add layers: POST `/project/api/projects/{projectId}/visualizations/{visualizationId}/layers`
```
[
    {
        "workspace": "incore",
        "layerId": "6375502f3a28a17d261fd682",
        "styleName": "incore:point"
    },
    {
        "workspace": "incore",
        "layerId": "6375502f3a28a17d261fd682",
        "styleName": "incore:point"
    }
]
```