### PR TITLE
339 add support for converting pgd from pga for the earthquake controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Sorted by option and order to the all project endpoints [#330](https://github.com/IN-CORE/incore-services/issues/330)
 - Endpoint to finalized a workflow [#335](https://github.com/IN-CORE/incore-services/issues/335)
+- Support for PGD from earthquake hazards [#339](https://github.com/IN-CORE/incore-services/issues/339)
 
 ### Fixed
 - Bug when adding visualization layers to an empty layer list [#331](https://github.com/IN-CORE/incore-services/issues/331)

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
@@ -204,7 +204,6 @@ public class HazardCalc {
                         "PGA", spectrumOverride, amplifyHazard, creator, userGroups, null);
                 Double updatedHazardVal = null;
                 if (result.getHazardValue() != null) {
-                    System.out.println("demand units are " + demandUnits);
                     updatedHazardVal = HazardUtil.convertHazard(result.getHazardValue(), "g", 0.0, HazardUtil.PGA, demandUnits,
                             HazardUtil.PGD);
                 }

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardCalc.java
@@ -187,6 +187,41 @@ public class HazardCalc {
                 return new SeismicHazardResult(updatedHazardValue, result.getPeriod(), result.getDemand(), demandUnits);
             }
 
+        } else if (HazardUtil.PGD.equalsIgnoreCase(hazardType)) {
+            // First, check if the hazard is directly from the attenuation models or datasets
+            boolean supported = supportsHazard(earthquake, attenuations, period, hazardType, true);
+            // If not supported, check if it supports PGA to convert PGA to PGD
+            if (!supported) {
+                supported = supportsHazard(earthquake, attenuations, "0.0", "PGA", true);
+
+                if (!supported) {
+                    throw new UnsupportedHazardException(hazardType + " is not supported and cannot be converted to given the defined " +
+                            "earthquake");
+                }
+                logger.debug(hazardType + " is not directly supported by the earthquake, using PGA to derive " + hazardType);
+
+                SeismicHazardResult result = computeGroundMotionAtSite(earthquake, attenuations, site, "0.0",
+                        "PGA", spectrumOverride, amplifyHazard, creator, userGroups, null);
+                Double updatedHazardVal = null;
+                if (result.getHazardValue() != null) {
+                    System.out.println("demand units are " + demandUnits);
+                    updatedHazardVal = HazardUtil.convertHazard(result.getHazardValue(), "g", 0.0, HazardUtil.PGA, demandUnits,
+                            HazardUtil.PGD);
+                }
+                return new SeismicHazardResult(updatedHazardVal, "0.0", HazardUtil.PGD, demandUnits);
+            } else {
+                // Before returning the result, make sure the requested demand unit matches the demand unit produced by the EQ
+                SeismicHazardResult result = computeGroundMotionAtSite(earthquake, attenuations, site, period, hazardType,
+                        spectrumOverride, amplifyHazard, creator, userGroups, demandUnits);
+                Double updatedHazardValue = null;
+                if (result.getHazardValue() != null) {
+                    updatedHazardValue = HazardUtil.convertHazard(result.getHazardValue(), result.getUnits(),
+                            Double.parseDouble(result.getPeriod()), result.getDemand(), demandUnits, result.getDemand());
+                }
+
+                return new SeismicHazardResult(updatedHazardValue, result.getPeriod(), result.getDemand(), demandUnits);
+            }
+
         } else {
             // TODO we need to modify this when we support spectrum methods
             boolean supported = supportsHazard(earthquake, attenuations, period, hazardType, false);

--- a/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardUtil.java
+++ b/server/hazard-service/src/main/java/edu/illinois/ncsa/incore/service/hazard/models/eq/utils/HazardUtil.java
@@ -336,11 +336,13 @@ public class HazardUtil {
     public static double getCorrectUnitsOfPGD(double pgd, String units0, String units1) {
         if (units0 != null && units0.equalsIgnoreCase(units1)) {
             return pgd;
-        } else if (units_m.equalsIgnoreCase(units0) || "m".equalsIgnoreCase(units0) && units_ft.equalsIgnoreCase(units1)) {
+        } else if (units_m.equalsIgnoreCase(units0) || "m".equalsIgnoreCase(units0) && (units_ft.equalsIgnoreCase(units1) || "ft".equalsIgnoreCase(units1))) {
             return pgd * 3.2808399;
         } else if (units_m.equalsIgnoreCase(units0) || "m".equalsIgnoreCase(units0) && units_cm.equalsIgnoreCase(units1)) {
             return pgd * 100.0;
-        } else {
+	} else if (units_m.equalsIgnoreCase(units0) || "m".equalsIgnoreCase(units0) && units_in.equalsIgnoreCase(units1)) {
+            return pgd * 39.3701;
+	} else {
             // Unknown type
             logger.warn("PGD unit type was " + units0 + ", but no conversion is implemented for units of " + units1);
             return pgd;

--- a/server/hazard-service/src/test/java/edu/illinois/ncsa/incore/service/hazard/models/eq/attenuations/AtkinsonBoore1995Test.java
+++ b/server/hazard-service/src/test/java/edu/illinois/ncsa/incore/service/hazard/models/eq/attenuations/AtkinsonBoore1995Test.java
@@ -62,13 +62,25 @@ public class AtkinsonBoore1995Test {
         // TODO this should come from a mock eq
         Earthquake eq = new EarthquakeModel();
         SeismicHazardResult result = HazardCalc.getGroundMotionAtSite(eq, attenuations, site, period, demand, HazardUtil.units_g,
-            0, true, null, "incrtest", "{\"groups\": [\"incore_user\"]}");
+                0, true, null, "incrtest", "{\"groups\": [\"incore_user\"]}");
 
         double expected = 0.5322;
         assertEquals(expected, result.getHazardValue(), expected * 0.05);
         assertEquals(result.getDemand(), HazardUtil.SA);
         assertEquals(result.getPeriod(), period);
         assertEquals(result.getUnits(), HazardUtil.units_g);
+
+        // Test PGD from PGA
+        period = "0.0";
+        demand = HazardUtil.PGD;
+        SeismicHazardResult result_pgd = HazardCalc.getGroundMotionAtSite(eq, attenuations, site, period, demand, HazardUtil.units_in,
+                0, true, null, "incrtest", "{\"groups\": [\"incore_user\"]}");
+
+        double expected_pgd = 3.269564;
+        assertEquals(expected_pgd, result_pgd.getHazardValue(), expected * 0.05);
+        assertEquals(result_pgd.getDemand(), HazardUtil.PGD);
+        assertEquals(result_pgd.getPeriod(), period);
+        assertEquals(result_pgd.getUnits(), HazardUtil.units_in);
     }
 
     @Test


### PR DESCRIPTION
Added a conditional to check if the requested hazard is PGD and if it's not directly supported by the attenuation, it calls an internal method that handles converting PGA to PGD (as long as the hazard supports PGA). 

I also added a unit test to verify it's working correctly.