### PR TITLE
Fixes #347 - changed order of delete dataset operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bug when posting additional fields which need to be ignored [#338](https://github.com/IN-CORE/incore-services/issues/338) 
 
 ### Changed
+- Order of delete dataset operations [#347](https://github.com/IN-CORE/incore-services/issues/347)
 - GeoTools to version 32.1 [#341](https://github.com/IN-CORE/incore-services/issues/341)
 
 ## [1.27.1] - 2024-11-01

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
@@ -483,11 +483,9 @@ public class DatasetController {
                 }
             }
             // remove dataset
-            logger.debug("Deleting dataset " + datasetId);
-            dataset = repository.deleteDataset(datasetId);
             if (dataset != null) {
                 logger.debug("Removing files from dataset " + datasetId);
-                // remove files
+                // First - remove the files from the dataset
                 List<FileDescriptor> fds = dataset.getFileDescriptors();
                 if (fds.size() > 0) {
                     for (FileDescriptor fd : fds) {
@@ -499,6 +497,10 @@ public class DatasetController {
                         }
                     }
                 }
+
+                // Files removed - delete the dataset entry
+                logger.debug("Deleting dataset " + datasetId);
+                dataset = repository.deleteDataset(datasetId);
 
                 // Adjust user quota after removing the dataset and files
                 // check if the dataset is hazard dataset

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
@@ -483,7 +483,7 @@ public class DatasetController {
                 }
             }
             // remove dataset
-	    logger.debug("Deleting dataset " + datasetId);
+            logger.debug("Deleting dataset " + datasetId);
             dataset = repository.deleteDataset(datasetId);
             if (dataset != null) {
                 logger.debug("Removing files from dataset " + datasetId);

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
@@ -483,8 +483,10 @@ public class DatasetController {
                 }
             }
             // remove dataset
+	    logger.debug("Deleting dataset " + datasetId);
             dataset = repository.deleteDataset(datasetId);
             if (dataset != null) {
+                logger.debug("Removing files from dataset " + datasetId);
                 // remove files
                 List<FileDescriptor> fds = dataset.getFileDescriptors();
                 if (fds.size() > 0) {
@@ -497,6 +499,32 @@ public class DatasetController {
                         }
                     }
                 }
+
+		// Adjust user quota after removing the dataset and files
+                // check if the dataset is hazard dataset
+                String dataType = dataset.getDataType();
+                String subDataType;
+                if (dataType.contains(":")) {
+                    // Compare what comes after the name space (e.g. probabilisticEarthquakeRaster from ergo:probabilisticEarthquakeRaster)
+                    subDataType = dataType.split(":")[1];
+                } else {
+                    subDataType = dataType;
+                }
+                boolean isHazardDataset = HazardConstants.DATA_TYPE_HAZARD.stream().anyMatch(s1 -> s1.contains(subDataType));
+
+                // reduce the number of hazard from the space
+                if (isHazardDataset) {
+	            logger.debug("Decreasing hazard dataset quota");
+                    AllocationUtils.decreaseUsage(allocationsRepository, this.username, "hazardDatasets");
+                } else {
+		    logger.debug("Decreasing dataset quota");
+                    AllocationUtils.decreaseUsage(allocationsRepository, this.username, "datasets");
+                }
+
+                // decrease file size to usage
+                UserAllocations allocation = allocationsRepository.getAllocationByUsername(username);
+                AllocationUtils.decreaseDatasetFileSize(allocation, allocationsRepository, fileSize, isHazardDataset);
+
                 // remove geoserver layer
                 if (geoserverUsed) {
                     boolean isRemoved = GeoserverUtils.removeStoreFromGeoserver(datasetId);
@@ -507,27 +535,6 @@ public class DatasetController {
                 this.username + " is not authorized to delete the dataset " + datasetId);
         }
 
-        // check if the dataset is hazard dataset
-        String dataType = dataset.getDataType();
-        String subDataType;
-        if (dataType.contains(":")) {
-            // Compare what comes after the name space (e.g. probabilisticEarthquakeRaster from ergo:probabilisticEarthquakeRaster)
-            subDataType = dataType.split(":")[1];
-        } else {
-            subDataType = dataType;
-        }
-        boolean isHazardDataset = HazardConstants.DATA_TYPE_HAZARD.stream().anyMatch(s1 -> s1.contains(subDataType));
-
-        // reduce the number of hazard from the space
-        if (isHazardDataset) {
-            AllocationUtils.decreaseUsage(allocationsRepository, this.username, "hazardDatasets");
-        } else {
-            AllocationUtils.decreaseUsage(allocationsRepository, this.username, "datasets");
-        }
-
-        // decrease file size to usage
-        UserAllocations allocation = allocationsRepository.getAllocationByUsername(username);
-        AllocationUtils.decreaseDatasetFileSize(allocation, allocationsRepository, fileSize, isHazardDataset);
 
         return dataset;
 

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/controllers/DatasetController.java
@@ -500,7 +500,7 @@ public class DatasetController {
                     }
                 }
 
-		// Adjust user quota after removing the dataset and files
+                // Adjust user quota after removing the dataset and files
                 // check if the dataset is hazard dataset
                 String dataType = dataset.getDataType();
                 String subDataType;
@@ -514,10 +514,10 @@ public class DatasetController {
 
                 // reduce the number of hazard from the space
                 if (isHazardDataset) {
-	            logger.debug("Decreasing hazard dataset quota");
+                    logger.debug("Decreasing hazard dataset quota");
                     AllocationUtils.decreaseUsage(allocationsRepository, this.username, "hazardDatasets");
                 } else {
-		    logger.debug("Decreasing dataset quota");
+                    logger.debug("Decreasing dataset quota");
                     AllocationUtils.decreaseUsage(allocationsRepository, this.username, "datasets");
                 }
 

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/FileUtils.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/FileUtils.java
@@ -180,7 +180,7 @@ public class FileUtils {
                 logger.error("file or directory did not deleted: " + delFileName);
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Error deleting files.", e);
         }
     }
 

--- a/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/FileUtils.java
+++ b/server/data-service/src/main/java/edu/illinois/ncsa/incore/service/data/utils/FileUtils.java
@@ -174,10 +174,12 @@ public class FileUtils {
      */
     public static void deleteFiles(File delFile, String delFileName) {
         try {
-            if (delFile.delete()) {
-                logger.debug("file or directory deleted: " + delFileName);
-            } else {
-                logger.error("file or directory did not deleted: " + delFileName);
+            if (delFile.exists()) {
+                if (delFile.delete()) {
+                    logger.debug("file or directory deleted: " + delFileName);
+                } else {
+                    logger.error("file or directory did not deleted: " + delFileName);
+                }
             }
         } catch (Exception e) {
             logger.error("Error deleting files.", e);


### PR DESCRIPTION
I changed the order of the delete dataset operation to hopefully improve readability and the logic. It seemed odd that we had the update user quota outside the code block where the delete dataset and remove file operations were happening. 

I also made the geoserver layer removal the last step.