### PR TITLE
Fixes #390 Sadigh et al 1997 attenuation model was missing from available models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- Sadigh et al 1997 attenuation model was missing from the list of available models [#390](https://github.com/IN-CORE/incore-services/issues/390)
+
+
 ## [1.29.0] - 2025-07-24
 
 ### Changed

--- a/server/hazard-service/src/main/resources/hazard-model.properties
+++ b/server/hazard-service/src/main/resources/hazard-model.properties
@@ -4,3 +4,4 @@ earthquake.attenuation.chiouyoungs2014=edu.illinois.ncsa.incore.service.hazard.m
 earthquake.attenuation.abrahamsonsilvakamai2014=edu.illinois.ncsa.incore.service.hazard.models.eq.attenuations.AbrahamsonSilvaKamai2014
 earthquake.attenuation.campbellbozorgnia2014=edu.illinois.ncsa.incore.service.hazard.models.eq.attenuations.CampbellBozorgnia2014
 earthquake.attenuation.toro1997=edu.illinois.ncsa.incore.service.hazard.models.eq.attenuations.Toro1997
+earthquake.attenuation.sadighchangeganmakdisiyoung1997=edu.illinois.ncsa.incore.service.hazard.models.eq.attenuations.SadighChangEganMakdisiYoung1997


### PR DESCRIPTION
If you run this branch, you should be able to see the available attenuations using the endpoint:

http://localhost:8080/hazard/api/earthquakes/models

Before this fix, SadighChangEganMakdisiYoung1997 was missing from the list. If you try the same endpoint on dev or prod, you will see the SadighChangEganMakdisiYoung1997 model is missing:

https://dev.in-core.org/hazard/api/earthquakes/models

Because it's missing, users cannot create EQ models with this attenuation. This fixes that.


